### PR TITLE
Bug fix for tallying tool theme counts

### DIFF
--- a/utils/tally_themes.py
+++ b/utils/tally_themes.py
@@ -21,6 +21,34 @@ CON_THEME_CTS = "syn21649281"
 THEME_CTS = "syn21639584"
 
 
+def _add_missing_themes(themes, df, label):
+    """Helper function: add missing themes with count = 0."""
+    missing_themes = themes[~themes.index.isin(df.index)].index.tolist()
+    for theme in missing_themes:
+        new_row = pd.DataFrame(
+            [[0, label]],
+            columns=['totalCount', 'groupBy'],
+            index=[theme]
+        )
+        df = pd.concat([df, new_row])
+    return df
+
+
+def _tally_portal_table(syn, table_id, colname, clause=False):
+    """Helper function: tally themes in portal table."""
+    query = f"SELECT {colname}, theme FROM {table_id}"
+    if clause:
+        query += " WHERE portalDisplay = true"
+    themes = (
+        syn.tableQuery(query)
+        .asDataFrame()
+        .explode('theme')
+        .groupby('theme')
+        .count()
+        .rename(columns={colname: "totalCount"})
+    )
+
+
 def tally_by_consortium(grants):
     """Portal - Consortium Counts (syn21641485)"""
     return (
@@ -52,33 +80,6 @@ def tally_by_theme_consortium(grants, themes):
     return res[~res['theme'].isin(['Computational Resource'])]
 
 
-def add_missing_themes(themes, df, label):
-    """Add missing themes from `themes` into `df` with count = 0."""
-    missing_themes = themes[~themes.index.isin(df.index)].index.tolist()
-    for theme in missing_themes:
-        new_row = pd.DataFrame(
-            [[0, label]],
-            columns=['totalCount', 'groupBy'],
-            index=[theme]
-        )
-        df = pd.concat([df, new_row])
-    return df
-
-
-def _tally_portal_table(syn, table_id, colname, clause=False):
-    """Helper function for tallying portal table."""
-    query = f"SELECT {colname}, theme FROM {table_id}"
-    if clause:
-        query += " WHERE portalDisplay = true"
-    return (
-        syn.tableQuery(query)
-        .asDataFrame()
-        .explode('theme')
-        .groupby('theme')
-        .count()
-        .rename(columns={colname: "totalCount"})
-    )
-
 def tally_by_group(syn, themes):
     """Portal - Theme Counts (syn21639584)"""
 
@@ -87,21 +88,21 @@ def tally_by_group(syn, themes):
         _tally_portal_table(syn, PUBS, "pubMedId")
         .assign(groupBy="publications")
     )
-    theme_pubs = add_missing_themes(themes, theme_pubs, 'publications')
+    theme_pubs = _add_missing_themes(themes, theme_pubs, 'publications')
 
     # get theme counts in datasets
     theme_datasets = (
         _tally_portal_table(syn, DATASETS, "pubMedId")
         .assign(groupBy="datasets")
     )
-    theme_datasets = add_missing_themes(themes, theme_datasets, 'datasets')
+    theme_datasets = _add_missing_themes(themes, theme_datasets, 'datasets')
 
     # get theme counts in tools
     theme_tools = (
         _tally_portal_table(syn, TOOLS, "toolName", clause=True)
         .assign(groupBy="tools")
     )
-    theme_tools = add_missing_themes(themes, theme_tools, 'tools')
+    theme_tools = _add_missing_themes(themes, theme_tools, 'tools')
 
     # concat results together
     res = (

--- a/utils/tally_themes.py
+++ b/utils/tally_themes.py
@@ -39,7 +39,7 @@ def _tally_portal_table(syn, table_id, colname, clause=False):
     query = f"SELECT {colname}, theme FROM {table_id}"
     if clause:
         query += " WHERE portalDisplay = true"
-    themes = (
+    return (
         syn.tableQuery(query)
         .asDataFrame()
         .explode('theme')

--- a/utils/tally_themes.py
+++ b/utils/tally_themes.py
@@ -65,44 +65,40 @@ def add_missing_themes(themes, df, label):
     return df
 
 
+def _tally_portal_table(syn, table_id, colname, clause=False):
+    """Helper function for tallying portal table."""
+    query = f"SELECT {colname}, theme FROM {table_id}"
+    if clause:
+        query += " WHERE portalDisplay = true"
+    return (
+        syn.tableQuery(query)
+        .asDataFrame()
+        .explode('theme')
+        .groupby('theme')
+        .count()
+        .rename(columns={colname: "totalCount"})
+    )
+
 def tally_by_group(syn, themes):
     """Portal - Theme Counts (syn21639584)"""
 
     # get theme counts in publications
-    publications = syn.tableQuery(
-        f"SELECT pubMedId, theme FROM {PUBS}").asDataFrame()
     theme_pubs = (
-        publications
-        .explode('theme')
-        .groupby('theme')
-        .count()
-        .rename(columns={'pubMedId': "totalCount"})
+        _tally_portal_table(syn, PUBS, "pubMedId")
         .assign(groupBy="publications")
     )
     theme_pubs = add_missing_themes(themes, theme_pubs, 'publications')
 
     # get theme counts in datasets
-    datasets = syn.tableQuery(
-        f"SELECT pubMedId, theme FROM {DATASETS}").asDataFrame()
     theme_datasets = (
-        datasets
-        .explode('theme')
-        .groupby('theme')
-        .count()
-        .rename(columns={'pubMedId': "totalCount"})
+        _tally_portal_table(syn, DATASETS, "pubMedId")
         .assign(groupBy="datasets")
     )
     theme_datasets = add_missing_themes(themes, theme_datasets, 'datasets')
 
     # get theme counts in tools
-    tools = syn.tableQuery(
-        f"SELECT toolName, theme FROM {TOOLS} WHERE portalDisplay = true").asDataFrame()
     theme_tools = (
-        tools
-        .explode('theme')
-        .groupby('theme')
-        .count()
-        .rename(columns={'toolName': "totalCount"})
+        _tally_portal_table(syn, TOOLS, "toolName", clause=True)
         .assign(groupBy="tools")
     )
     theme_tools = add_missing_themes(themes, theme_tools, 'tools')

--- a/utils/tally_themes.py
+++ b/utils/tally_themes.py
@@ -65,7 +65,7 @@ def add_missing_themes(themes, df, label):
     return df
 
 
-def tally_by_group(syn, grants, themes):
+def tally_by_group(syn, themes):
     """Portal - Theme Counts (syn21639584)"""
 
     # get theme counts in publications
@@ -96,12 +96,9 @@ def tally_by_group(syn, grants, themes):
 
     # get theme counts in tools
     tools = syn.tableQuery(
-        f"SELECT toolName, grantNumber FROM {TOOLS}").asDataFrame()
+        f"SELECT toolName, theme FROM {TOOLS} WHERE portalDisplay = true").asDataFrame()
     theme_tools = (
         tools
-        .explode('grantNumber')
-        .set_index('grantNumber')
-        .join(grants[['grantNumber', 'theme']].set_index('grantNumber'))
         .explode('theme')
         .groupby('theme')
         .count()
@@ -150,7 +147,7 @@ def main():
 
     consortium_counts = tally_by_consortium(grants)
     theme_consortium_counts = tally_by_theme_consortium(grants, themes)
-    theme_counts = tally_by_group(syn, grants, themes)
+    theme_counts = tally_by_group(syn, themes)
 
     update_table(syn, CONSORTIUM_CTS, consortium_counts)
     update_table(syn, CON_THEME_CTS, theme_consortium_counts)


### PR DESCRIPTION
Prior to today, the tools portal table did not include a `theme` column, which consequently meant tallying up their themes required some workarounds with the grants table.  Unfortunately, this workaround was not correct.

That being said, now that the tools portal table _does_ include `theme`, the counts can accurately be measured :-)