### PR TITLE
Output split manifests as Excel files

### DIFF
--- a/annotations/split_manifest_grants.py
+++ b/annotations/split_manifest_grants.py
@@ -1,6 +1,6 @@
 """Split Manifests CSV
 This script will split a manifest csv by grant number and output
-results into individual CSVs.
+results into individual Excel files.
 author: verena.chung
 author: brynn.zalmanek
 """
@@ -31,12 +31,12 @@ def get_args():
     return parser.parse_args()
 
 
-def generate_manifest_as_excel(table, cv_terms, output):
-    """Generate manifest file (xlsx) with given publications data."""
+def generate_manifest_as_excel(df, cv_terms, output):
+    """Generate manifest file (xlsx) with given df."""
     wb = Workbook()
     ws = wb.active
     ws.title = "manifest"
-    for r in dataframe_to_rows(table, index=False, header=True):
+    for r in dataframe_to_rows(df, index=False, header=True):
         ws.append(r)
 
     ws2 = wb.create_sheet("standard_terms")
@@ -56,7 +56,7 @@ def generate_manifest_as_excel(table, cv_terms, output):
 
 
 def split_manifest(df, manifest_type):
-    """Split manifest into multiple manifests by grant number"""
+    """Split manifest into multiple manifests by grant number."""
     colname = f"{manifest_type.capitalize()} Grant Number"
 
     df[colname] = df[colname].str.split(", ")

--- a/annotations/split_manifest_grants.py
+++ b/annotations/split_manifest_grants.py
@@ -77,11 +77,11 @@ def main():
         os.makedirs(output_dir)
 
     # Get latest CV terms to save as "standard_terms" - only keeping
-    # terms relevant to the manifest type.
+    # the terms relevant to the manifest type.
     manifest_type = args.manifest_type
-    annots = ['assay', 'tissue', 'tumorType']
+    annots = ["assay", "tissue", "tumorType"]
 
-    cv_file = 'https://raw.githubusercontent.com/mc2-center/data-models/main/all_valid_values.csv'
+    cv_file = "https://raw.githubusercontent.com/mc2-center/data-models/main/all_valid_values.csv"
     cv_terms = pd.read_csv(cv_file)
     cv_terms = cv_terms.loc[cv_terms['category'].str.contains(manifest_type) |
                             cv_terms['category'].isin(annots)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-synapseclient >= 2.7.0
 pandas >= 1.5.1
 openpyxl >= 3.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+synapseclient >= 2.7.0
+pandas >= 1.5.1
+openpyxl >= 3.0.10


### PR DESCRIPTION
Fixes #24.  In particular:

* split manifests will output as Excel files
* each generated manifest will include a secondary sheet of standard terms (currently queries this [Synapse table](https://www.synapse.org/#!Synapse:syn26433610/tables/), but I'm guessing we should use [this source](https://github.com/mc2-center/mc2-data-models/tree/main/modules/shared) instead?)
* (just for robustness) create output folder if it doesn't already exist