### PR TITLE
Feature: create new team for grant project

### DIFF
--- a/portal_tables/sync_grants.py
+++ b/portal_tables/sync_grants.py
@@ -151,9 +151,9 @@ def create_grant_projects(syn, grants):
             project = Project(name)
             project = syn.store(project)
             syn.setPermissions(
-                project.id, principalId=3450948,
-                accessType=['CREATE', 'READ', 'UPDATE', 'DELETE', 'DOWNLOAD',
-                            'CHANGE_PERMISSIONS', 'CHANGE_SETTINGS', 'MODERATE'],
+                project.id,
+                principalId=3450948,
+                accessType=PERMISSIONS.get("admin")
             )
 
             # Update grants table with new synId

--- a/portal_tables/sync_grants.py
+++ b/portal_tables/sync_grants.py
@@ -2,7 +2,8 @@
 
 This script will sync over new grants and its annotations to the
 Grants portal table. A Synapse Project with pre-filled Wikis and
-Folders will also be created for each new grant found.
+Folders will also be created for each new grant found, as well as
+a Synapse team.
 """
 
 import argparse

--- a/portal_tables/sync_grants.py
+++ b/portal_tables/sync_grants.py
@@ -227,7 +227,7 @@ def main():
     else:
         print(f"{len(new_grants)} new grants found!\n")
         if args.dryrun:
-            print(u"\u26A0", "WARNING:",
+            print("\u26A0", "WARNING:",
                   "dryrun is enabled (no updates will be done)\n")
             print(new_grants)
         else:


### PR DESCRIPTION
Currently, each new grant will generate a new Synapse project that is only accessible to the creator and the MC2 Admin team (both with "admin" permissions).  In order to enable community curation and contributions through the DCA, we will additionally need to allow access to each center / contributor.

This PR will create a new team with "edit" permissions to the newly-created project, using the naming format:

“[Consortia] [Center Alias] UXX CAXXXXXX”