### PR TITLE
[Bug fix]: tally graphs update fail

### DIFF
--- a/.github/workflows/update-theme-graphs.yml
+++ b/.github/workflows/update-theme-graphs.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/utils/tally_themes.py
+++ b/utils/tally_themes.py
@@ -51,6 +51,7 @@ def _tally_portal_table(syn, table_id, colname, clause=False):
 
 def tally_by_consortium(grants):
     """Portal - Consortium Counts (syn21641485)"""
+    grants['consortium'] = grants['consortium'].str.join(", ")
     return (
         grants[['grantId', 'consortium']]
         .groupby('consortium')


### PR DESCRIPTION
Table schema for grants recently updated, which resulted in a workflow fail.  Specifically: `consortium` is now a STRINGLIST, which is not hashable by `groupby()`.

This PR will address that issue.