### PR TITLE
Sync script updates

### DIFF
--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -95,9 +95,6 @@ def sync_table(syn, pubs, table, dryrun):
         print("Synchronizing publications staging database to production database...\n")
         table_rows = pubs.values.tolist()
         syn.store(Table(schema, table_rows))
-
-    else:
-        None
     
     return pubs
     

--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -68,7 +68,7 @@ def add_missing_info(pubs, grants, new_cols):
                     print(f"No match found for grant number: {g}")
                     continue
             
-            clean_values = list((dict.fromkeys(extracted)))
+            clean_values = list(dict.fromkeys(extracted))
 
             pubs.at[i, col] = clean_values
     

--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -5,27 +5,30 @@ Publications portal table.
 """
 
 import argparse
-
 from synapseclient import Table
+import pandas as pd
+import re
 import utils
-
-
 
 def get_args():
     """Set up command-line interface and get arguments."""
     parser = argparse.ArgumentParser(description="Add new pubs to the CCKP")
     parser.add_argument("-m", "--manifest",
-                        type=str, default="syn35477535",
-                        help="Synapse ID to the manifest table/fileview.")
+                        type=str, default="syn53478776",
+                        help="Synapse ID to the staging version of publication database CSV.")
     parser.add_argument("-t", "--portal_table",
                         type=str, default="syn21868591",
                         help=("Add publications to this specified "
                               "table. (Default: syn21868591)"))
+    parser.add_argument("-p", "--table_path",
+                        type=str, default="./final_table.csv",
+                        help=("Path at which to store the final CSV. "
+                              "Defaults to './final_table.csv'"))
     parser.add_argument("--dryrun", action="store_true")
     return parser.parse_args()
 
 
-def add_missing_info(pubs, grants):
+def add_missing_info(pubs, grants, new_cols):
     """Add missing information into table before syncing.
 
     Returns:
@@ -34,81 +37,115 @@ def add_missing_info(pubs, grants):
     pubs.loc[:, 'Link'] = [
         "".join(["[PMID:", str(pmid), "](", url, ")"])
         for pmid, url
-        in zip(pubs.pubmedId, pubs.pubmedUrl)
+        in zip(pubs['Pubmed Id'], pubs['Pubmed Url'])
     ]
-    pubs['grantName'] = ""
-    for i, row in pubs.iterrows():
-        grant_names = []
-        for g in row['publicationGrantNumber']:
-            grant_names.append(
-                grants[grants.grantNumber == g]['grantName'].values[0])
-        pubs.at[i, 'grantName'] = grant_names
+    
+    pattern = re.compile("(\')([\s\w/-]+)(\')")
+    
+    for col in new_cols: 
+        pubs[col] = ""
+        for row in pubs.itertuples():
+            i = row[0]
+            n = row[4].split(",")
+            extracted = []
+            for g in n:
+                if len(grants[grants.grantNumber == g][col].values) > 0:
+                    values = str(grants[grants.grantNumber == g][col].values[0])
+                    
+                    if col == 'grantName':
+                        extracted.append(values)
+                    
+                    else:
+                        matches = pattern.findall(values)
+                        for m in matches:
+                            extracted.append(m[1])
+
+                else:
+                    print(f"No match found for grant number: {g}")
+                    continue
+            
+            clean_values = ', '.join(list((dict.fromkeys(extracted))))
+
+            pubs.at[i, col] = clean_values
+    
     return pubs
 
 
-def sync_table(syn, pubs, table):
+def sync_table(syn, pubs, table, dryrun):
     """Add pubs annotations to the Synapse table."""
     schema = syn.get(table)
 
     # Reorder columns to match the table order.
     col_order = [
-        'publicationDoi', 'publicationJournal', 'pubmedId', 'pubmedUrl',
-        'Link', 'publicationTitle', 'publicationYear', 'publicationKeywords',
-        'publicationAuthors', 'publicationAbstract', 'publicationAssay', 
-        'publicationTumorType', 'publicationTissue', 'publicationThemeName',
-        'publicationConsortiumName', 'publicationGrantNumber', 'grantName',
-        'publicationDatasetAlias', 'publicationAccessibility'
+        'Publication Doi', 'Publication Journal', 'Pubmed Id', 'Pubmed Url',
+        'Link', 'Publication Title', 'Publication Year', 'Publication Keywords',
+        'Publication Authors', 'Publication Abstract', 'Publication Assay', 
+        'Publication Tumor Type', 'Publication Tissue', 'theme',
+        'consortium', 'Publication Grant Number', 'grantName',
+        'Publication Dataset Alias', 'Publication Accessibility',
+        'entityId'
     ]
     pubs = pubs[col_order]
 
     # Convert list column into string to match with table schema.
-    pubs.loc[:, 'publicationDatasetAlias'] = (
-        pubs['publicationDatasetAlias']
-        .str.join(", ")
-    )
+    #pubs.loc[:, 'Publication Dataset Alias'] = (
+    #    pubs['Publication Dataset Alias']
+    #    .str.join(", ")
+    #)
 
-    new_rows = pubs.values.tolist()
-    syn.store(Table(schema, new_rows))
+    if dryrun:
+        print(u"\u26A0", "WARNING:",
+            "dryrun is enabled (no updates will be done)\n")
 
+    else:
+        print("Synchronizing publications staging database to production database...\n", pubs)
+        table_rows = pubs.values.tolist()
+        syn.store(Table(schema, table_rows))
+
+    return pubs
 
 def main():
     """Main function."""
     syn = utils.syn_login()
     args = get_args()
 
+    new_cols = [
+        'theme',
+        'consortium',
+        'grantName'
+    ]
+
+    if args.dryrun:
+        print(
+        "Inputs will be processed and provided for review", 
+        "\n\nDatabase will NOT be updated."
+    )
+    
     manifest = (
-        syn.tableQuery(f"SELECT * FROM {args.manifest}")
-        .asDataFrame()
-        .fillna("")
-    )
-    curr_pubs = (
-        syn.tableQuery(f"SELECT pubMedId FROM {args.portal_table}")
-        .asDataFrame()
-        .pubMedId
-        .to_list()
+        pd.read_csv(
+        syn.get(args.manifest).path,
+        header=0).fillna("")
     )
 
-    # Only add pubs not currently in the Publications table.
-    new_pubs = manifest[~manifest['pubmedId'].isin(curr_pubs)]
-    if new_pubs.empty:
-        print("No new publications found!")
-    else:
-        print(f"{len(new_pubs)} new publications found!\n")
-        if args.dryrun:
-            print(u"\u26A0", "WARNING:",
-                  "dryrun is enabled (no updates will be done)\n")
-            print(new_pubs)
-        else:
-            print("Adding new publications...")
-            grants = (
-                syn.tableQuery(
-                    "SELECT grantNumber, grantName FROM syn21918972")
-                .asDataFrame()
-            )
-            new_pubs = add_missing_info(new_pubs.copy(), grants)
-            sync_table(syn, new_pubs.copy(), args.portal_table)
+    print("\n\nCSV downloaded from Synapse:\n", manifest)
+
+    grants = (
+        syn.tableQuery(
+            f"SELECT grantNumber, {','.join(new_cols)} FROM syn21918972")
+            .asDataFrame()
+    )
+    
+    print("\n\nProcessing publications staging database...")
+        
+    database = add_missing_info(manifest.copy(), grants, new_cols)
+    print("\n\nTable with all requested columns added:\n", database)
+
+    new_table = sync_table(syn, database.copy(), args.portal_table, args.dryrun)
+    print("\n\nReordered final table - to be synced to database:\n", new_table)
+
+    new_table.to_csv(args.table_path, index=False)
+    print(f"Copy of final table stored at: {args.table_path}")
     print("DONE ✓")
-
-
+        
 if __name__ == "__main__":
     main()

--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -91,7 +91,7 @@ def sync_table(syn, pubs, table, dryrun):
     ]
     pubs = pubs[col_order]
 
-    if dryrun is False:
+    if not dryrun:
         print("Synchronizing publications staging database to production database...\n")
         table_rows = pubs.values.tolist()
         syn.store(Table(schema, table_rows))

--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -87,12 +87,6 @@ def sync_table(syn, pubs, table, dryrun):
     ]
     pubs = pubs[col_order]
 
-    # Convert list column into string to match with table schema.
-    #pubs.loc[:, 'Publication Dataset Alias'] = (
-    #    pubs['Publication Dataset Alias']
-    #    .str.join(", ")
-    #)
-
     if dryrun:
         print(u"\u26A0", "WARNING:",
             "dryrun is enabled (no updates will be done)\n")

--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -64,7 +64,7 @@ def add_missing_info(pubs, grants, new_cols):
                     print(f"No match found for grant number: {g}")
                     continue
             
-            clean_values = ', '.join(list((dict.fromkeys(extracted))))
+            clean_values = list((dict.fromkeys(extracted)))
 
             pubs.at[i, col] = clean_values
     


### PR DESCRIPTION
Updating sync_publications.py to allow CSVs to be synced to CCKP database

- support use of staging CSVs, instead of tables
- extract 'theme', 'grantName', and 'consortium' information from Grants - Merged table and add to each publication listed
- default manifest set as "syn53478776", the current synId for the PublicationView staging database CSV
- remove dataset alias column conversion to string, since reading from CSV appears to produce strings