### PR TITLE
[fix]: convert select columns to list

### DIFF
--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -90,9 +90,23 @@ def add_missing_info(pubs, grants, new_cols):
     return pubs
 
 
+def convert_to_stringlist(col):
+    """Convert a string column to a list."""
+    return col.str.replace(", ", ",").str.split(",")
+
+
 def sync_table(syn, pubs, table, dryrun):
     """Add pubs annotations to the Synapse table."""
     schema = syn.get(table)
+
+    # Convert string columns to string-list.
+    for col in [
+        "Publication Assay",
+        "Publication Tumor Type",
+        "Publication Tissue",
+        "Publication Grant Number",
+    ]:
+        pubs[col] = convert_to_stringlist(pubs[col])
 
     # Reorder columns to match the table order.
     col_order = [


### PR DESCRIPTION
Fixes #43 

## Changelog
* add a new function: `convert_to_stringlist()` that will accept a Pandas series, replace all instances of `, ` (trailing space) with `,` (no space), then split the string by `,`
* convert the following columns to a list prior to syncing:
   * `Publication Assay`
   * `Publication Tumor Type`
   * `Publication Tissue`
   * `Publication Grant Number`