### PR TITLE
[feat]: Update publications syncing script

### DIFF
--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -102,6 +102,10 @@ def clean_table(datasets):
     ]:
         df[col] = utils.convert_to_stringlist(df[col])
 
+    # We only need one synID for the portal table. See
+    # https://github.com/mc2-center/mc2-center-dcc/pull/41#issuecomment-1955119623
+    # for more context.
+    df["DatasetView_id"] = df["DatasetView_id"].str[0]
 
     # Reorder columns to match the table order.
     col_order = [
@@ -123,8 +127,7 @@ def clean_table(datasets):
         "pub",
         "link",
     ]
-    datasets = datasets[col_order].explode("DatasetView_id")  # FIXME?
-    return datasets
+    return df[col_order]
 
 
 def main():

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -47,13 +47,6 @@ def get_args():
     return parser.parse_args()
 
 
-# def create_folder(syn, name, parent):
-#     name = name.replace("/", "-")
-#     folder = Folder(name, parent=parent)
-#     folder = syn.store(folder)
-#     return folder.id
-
-
 def sort_and_stringify_col(col):
     """Sort list col then join together as comma-separated string."""
     # Check column by looking at first row; if str, convert to list first.
@@ -82,15 +75,6 @@ def add_missing_info(datasets, grants, pubs):
     datasets["consortia"] = ""
     datasets["pub"] = ""
     for _, row in datasets.iterrows():
-        # if re.search(r"^syn\d+$", row["datasetAlias"]):
-        #     folder_id = row["datasetAlias"]
-        # else:
-        #     grant_proj = grants[grants.grantNumber == row["datasetGrantNumber"][0]][
-        #         "grantId"
-        #     ].values[0]
-        #     folder_id = ""
-        #     folder_id = create_folder(syn, row["datasetAlias"], grant_proj)
-        # datasets.at[_, "id"] = folder_id
         grant_names = []
         themes = set()
         consortia = set()

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -158,7 +158,7 @@ def clean_table(datasets):
         "pub",
         "link",
     ]
-    datasets = datasets[col_order].explode("DatasetView_id")
+    datasets = datasets[col_order].explode("DatasetView_id")  # FIXME?
     return datasets
 
 
@@ -189,7 +189,7 @@ def main():
         pass  # Destination table is empty.
 
     # Only add datasets not currently in the Datasets table, using
-    # dataset alias + grant number to determine uniqueness.
+    # dataset alias + grant number to determine uniqueness. - FIXME?
     new_datasets = pd.merge(
         manifest,
         curr_datasets,

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -7,8 +7,8 @@ new dataset in its respective grant Project.
 
 import argparse
 
-import re
-from synapseclient import Table, Folder
+# import re
+from synapseclient import Table #, Folder
 import pandas as pd
 import utils
 
@@ -47,14 +47,14 @@ def get_args():
     return parser.parse_args()
 
 
-def create_folder(syn, name, parent):
-    name = name.replace("/", "-")
-    folder = Folder(name, parent=parent)
-    folder = syn.store(folder)
-    return folder.id
+# def create_folder(syn, name, parent):
+#     name = name.replace("/", "-")
+#     folder = Folder(name, parent=parent)
+#     folder = syn.store(folder)
+#     return folder.id
 
 
-def add_missing_info(syn, datasets, grants, pubs):
+def add_missing_info(datasets, grants, pubs):
     """Add missing information into table before syncing.
 
     Returns:
@@ -69,14 +69,15 @@ def add_missing_info(syn, datasets, grants, pubs):
     datasets['consortia'] = ""
     datasets['pub'] = ""
     for _, row in datasets.iterrows():
-        if re.search(r"^syn\d+$", row['datasetAlias']):
-            folder_id = row['datasetAlias']
-        else:
-            grant_proj = grants[grants.grantNumber ==
-                                row['datasetGrantNumber'][0]]['grantId'].values[0]
-            folder_id = ""
-            folder_id = create_folder(syn, row['datasetAlias'], grant_proj)
-        datasets.at[_, 'id'] = folder_id
+        # if re.search(r"^syn\d+$", row["datasetAlias"]):
+        #     folder_id = row["datasetAlias"]
+        # else:
+        #     grant_proj = grants[grants.grantNumber == row["datasetGrantNumber"][0]][
+        #         "grantId"
+        #     ].values[0]
+        #     folder_id = ""
+        #     folder_id = create_folder(syn, row["datasetAlias"], grant_proj)
+        # datasets.at[_, "id"] = folder_id
         grant_names = []
         themes = set()
         consortia = set()

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -15,16 +15,35 @@ import utils
 
 def get_args():
     """Set up command-line interface and get arguments."""
-    parser = argparse.ArgumentParser(
-        description="Add new datasets to the CCKP")
-    parser.add_argument("-m", "--manifest",
-                        type=str, default="syn35492812",
-                        help="Synapse ID to the manifest table/fileview.")
-    parser.add_argument("-t", "--portal_table",
-                        type=str, default="syn21897968",
-                        help=("Add datasets to this specified "
-                              "table. (Default: syn21897968)"))
+    parser = argparse.ArgumentParser(description="Add new datasets to the CCKP")
+    parser.add_argument(
+        "-m",
+        "--manifest_id",
+        type=str,
+        default="syn53478774",
+        help="Synapse ID to the manifest CSV file.",
+    )
+    parser.add_argument(
+        "-t",
+        "--portal_table_id",
+        type=str,
+        default="syn21897968",
+        help="Add datasets to this specified table. (Default: syn21897968)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_csv",
+        type=str,
+        default="./final_dataset_table.csv",
+        help="Filepath to output CSV.",
+    )
     parser.add_argument("--dryrun", action="store_true")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Output all logs and interim tables.",
+    )
     return parser.parse_args()
 
 

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -183,7 +183,7 @@ def main():
         indicator=True,
     ).query("_merge=='left_only'")
     if new_datasets.empty:
-        print("🚫 No new datasets found!")
+        print("🚫 No new datasets found! Nothing to sync.")
     else:
         print(f"🆕 {len(new_datasets)} new datasets found!\n")
 

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -167,8 +167,9 @@ def main():
 
     if not args.dryrun:
         utils.update_table(syn, args.portal_table_id, final_database)
+        print()
 
-    print(f"Saving copy of final table to: {args.output_csv}...")
+    print(f"📄 Saving copy of final table to: {args.output_csv}...")
     final_database.to_csv(args.output_csv, index=False)
     print("\n\nDONE ✅")
 

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -118,8 +118,11 @@ def sync_table(syn, datasets, table):
 
 
 def sort_and_stringify_col(col):
-    """Sort list col then join together as comma-sep string."""
-    return col.apply(lambda x: ", ".join(map(str, sorted(x))))
+    """Sort list col then join together as comma-separated string."""
+    # Check column by looking at first row; if str, convert to list first.
+    if isinstance(col.iloc[0], str):
+        col = col.str.replace(", ", ",").str.split(",")
+    return col.apply(lambda x: ",".join(map(str, sorted(x))))
 
 
 def main():

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -64,10 +64,10 @@ def add_missing_info(datasets, grants, pubs):
         "".join(["[", d_id, "](", url, ")"]) if url else ""
         for d_id, url in zip(datasets["DatasetAlias"], datasets["DatasetUrl"])
     ]
-    datasets['grantName'] = ""
-    datasets['themes'] = ""
-    datasets['consortia'] = ""
-    datasets['pub'] = ""
+    datasets["grantName"] = ""
+    datasets["themes"] = ""
+    datasets["consortia"] = ""
+    datasets["pub"] = ""
     for _, row in datasets.iterrows():
         # if re.search(r"^syn\d+$", row["datasetAlias"]):
         #     folder_id = row["datasetAlias"]
@@ -81,20 +81,28 @@ def add_missing_info(datasets, grants, pubs):
         grant_names = []
         themes = set()
         consortia = set()
-        for g in row['datasetGrantNumber']:
-            grant_names.append(grants[grants.grantNumber == g]
-                               ['grantName'].values[0])
-            themes.update(grants[grants.grantNumber == g]
-                          ['theme'].values[0])
-            consortia.update(grants[grants.grantNumber == g]
-                          ['consortium'].values[0])
-        datasets.at[_, 'grantName'] = grant_names
-        datasets.at[_, 'themes'] = list(themes)
-        datasets.at[_, 'consortia'] = list(consortia)
+        for g in row["DatasetGrantNumber"].split(","):
+            if g != "Affiliated/Non-Grant Associated":
+                grant_names.append(
+                    grants[grants.grantNumber == g]["grantName"].values[0]
+                )
+                themes.update(grants[grants.grantNumber == g]["theme"].values[0])
+                consortia.update(
+                    grants[grants.grantNumber == g]["consortium"].values[0]
+                )
+        datasets.at[_, "grantName"] = grant_names
+        datasets.at[_, "themes"] = list(themes)
+        datasets.at[_, "consortia"] = list(consortia)
+
         pub_titles = []
-        for p in row["datasetPubmedId"]:
-            pub_titles.append(pubs[pubs.pubMedId == int(p)]
-                              ["publicationTitle"].values[0])
+        for p in row["DatasetPubmedId"].split(","):
+            p = p.strip()  # remove leading/trailing whitespace, if any
+            try:
+                pub_titles.append(
+                    pubs[pubs.pubMedId == int(p)]["publicationTitle"].values[0]
+                )
+            except (ValueError, IndexError):
+                pass  # PMID not yet annotated or found in portal table
         datasets.at[_, "pub"] = pub_titles
     return datasets
 

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -148,38 +148,7 @@ def main():
         print(manifest)
         print()
 
-    curr_datasets = syn.tableQuery(
-        f"SELECT datasetAlias, grantNumber FROM {args.portal_table_id}"
-    ).asDataFrame()
-    try:
-        curr_datasets["grantNumber"] = sort_and_stringify_col(
-            curr_datasets["grantNumber"]
-        )
-    except IndexError:
-        pass  # Destination table is empty.
-
-    # Only add datasets not currently in the Datasets table, using
-    # dataset alias + grant number to determine uniqueness. - FIXME?
-    new_datasets = pd.merge(
-        manifest,
-        curr_datasets,
-        how="left",
-        left_on=["DatasetAlias", "DatasetGrantNumber"],
-        right_on=["datasetAlias", "grantNumber"],
-        indicator=True,
-    ).query("_merge=='left_only'")
-    if new_datasets.empty:
-        print("🚫 No new datasets found! Nothing to sync.")
-    else:
-        print(f"🆕 {len(new_datasets)} new datasets found!\n")
-
-        print("Processing dataset staging database...")
-        grants = syn.tableQuery(
-            "SELECT grantId, grantNumber, grantName, theme, consortium FROM syn21918972"
-        ).asDataFrame()
-        pubs = syn.tableQuery(
-            "SELECT pubMedId, publicationTitle FROM syn21868591"
-        ).asDataFrame()
+    print("Processing dataset staging database...")
 
         new_datasets = add_missing_info(new_datasets, grants, pubs)
         new_datasets = clean_table(new_datasets)

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -200,6 +200,10 @@ def main():
                 print(new_datasets)
             sync_table(syn, new_datasets, args.portal_table_id)
 
+            print(f"Saving copy of final table to: {args.output_csv}...")
+            new_datasets.to_csv(args.output_csv, index=False)
+            print("\n\nDONE ✅")
+
 
 if __name__ == "__main__":
     main()

--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -24,7 +24,7 @@ def get_args():
     )
     parser.add_argument(
         "-t",
-        "--portal_table",
+        "--portal_table_id",
         type=str,
         default="syn21868591",
         help=("Add publications to this specified " "table. (Default: syn21868591)"),
@@ -33,7 +33,7 @@ def get_args():
         "-p",
         "--table_path",
         type=str,
-        default="./final_table.csv",
+        default="./final_publication_table.csv",
         help=(
             "Path at which to store the final CSV. " "Defaults to './final_table.csv'"
         ),

--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -4,10 +4,11 @@ This script will sync over new publications and its annotations to the
 Publications portal table.
 """
 
-import argparse
-from synapseclient import Table
-import pandas as pd
 import re
+import argparse
+from typing import List
+
+import pandas as pd
 import utils
 
 

--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -136,28 +136,30 @@ def main():
         )
 
     manifest = pd.read_csv(syn.get(args.manifest).path, header=0).fillna("")
-
     if args.verbose:
-        print("\n\nCSV downloaded from Synapse:\n", manifest)
+        print("🔍 Preview of manifest CSV:\n" + "=" * 72)
+        print(manifest)
+        print()
 
+    print("\nProcessing publications staging database...")
     grants = syn.tableQuery(
         f"SELECT grantNumber, {','.join(new_cols)} FROM syn21918972"
     ).asDataFrame()
 
-    print("\nProcessing publications staging database...")
-
-    database = add_missing_info(manifest.copy(), grants, new_cols)
+    database = add_missing_info(manifest, grants, new_cols)
+    final_database = clean_table(database)
     if args.verbose:
-        print("\n\nTable with all requested columns added:\n", database)
+        print("\n🔍 Publication(s) to be synced:\n" + "=" * 72)
+        print(final_database)
+        print()
 
-    new_table = sync_table(syn, database.copy(), args.portal_table, args.dryrun)
-    if args.verbose:
-        print("\n\nReordered final table - to be synced to database:\n", new_table)
+    if not args.dryrun:
+        utils.update_table(syn, args.portal_table_id, final_database)
+        print()
 
-    new_table.to_csv(args.table_path, index=False)
-    print(f"\nCopy of final table stored at: {args.table_path}")
-
-    print("\nDONE ✓")
+    print(f"📄 Saving copy of final table to: {args.table_path}...")
+    final_database.to_csv(args.table_path, index=False)
+    print("\n\nDONE ✅")
 
 
 if __name__ == "__main__":

--- a/portal_tables/utils.py
+++ b/portal_tables/utils.py
@@ -2,6 +2,7 @@ import os
 import getpass
 
 import synapseclient
+import pandas as pd
 
 
 def syn_login():
@@ -21,3 +22,24 @@ def syn_login():
         password = getpass.getpass("Synapse password: ")
         syn = synapseclient.login(username, password, silent=True)
     return syn
+
+
+def sort_and_stringify_col(col: pd.Series) -> str:
+    """Sort list col then join together as comma-separated string."""
+    # Check column by looking at first row; if str, convert to list first.
+    if isinstance(col.iloc[0], str):
+        col = col.str.replace(", ", ",").str.split(",")
+    return col.apply(lambda x: ",".join(map(str, sorted(x))))
+
+
+def convert_to_stringlist(col: pd.Series) -> pd.Series:
+    """Convert a string column to a list."""
+    return col.str.replace(", ", ",").str.split(",")
+
+
+def update_table(syn: synapseclient.Synapse, table_id: str, df: pd.DataFrame) -> None:
+    """Truncate table then add rows from latest manifest."""
+    current_rows = syn.tableQuery(f"SELECT * FROM {table_id}")
+    syn.delete(current_rows)
+    new_rows = df.values.tolist()
+    syn.store(synapseclient.Table(table_id, new_rows))

--- a/portal_tables/utils.py
+++ b/portal_tables/utils.py
@@ -48,7 +48,7 @@ def update_table(syn: synapseclient.Synapse, table_id: str, df: pd.DataFrame) ->
         - sync over rows from the latest manifest
     """
 
-    today = datetime.today().strftime('%Y-%m-%d')
+    today = datetime.today().strftime("%Y-%m-%d")
     print(f"Creating new table version with label: {today}...")
     syn.create_snapshot_version(table_id, label=today)
 

--- a/portal_tables/utils.py
+++ b/portal_tables/utils.py
@@ -40,6 +40,8 @@ def convert_to_stringlist(col: pd.Series) -> pd.Series:
 
 def update_table(syn: synapseclient.Synapse, table_id: str, df: pd.DataFrame) -> None:
     """Truncate table then add rows from latest manifest."""
+
+    print("Syncing table with latest data...\n")
     current_rows = syn.tableQuery(f"SELECT * FROM {table_id}")
     syn.delete(current_rows)
     new_rows = df.values.tolist()

--- a/portal_tables/utils.py
+++ b/portal_tables/utils.py
@@ -1,11 +1,10 @@
-import os
-import getpass
+from getpass import getpass
 
 import synapseclient
 import pandas as pd
 
 
-def syn_login():
+def syn_login() -> synapseclient.Synapse:
     """Log into Synapse. If env variables not found, prompt user.
 
     Returns:
@@ -16,11 +15,13 @@ def syn_login():
             authToken=os.getenv('SYNAPSE_AUTH_TOKEN'),
             silent=True)
     except synapseclient.core.exceptions.SynapseNoCredentialsError:
-        print("Credentials not found; please manually provide your",
-              "Synapse username and password.")
-        username = input("Synapse username: ")
-        password = getpass.getpass("Synapse password: ")
-        syn = synapseclient.login(username, password, silent=True)
+        print(
+            "Credentials not found; please manually provide your",
+            "Synapse Personal Access Token (PAT). You can generate"
+            "one at https://www.synapse.org/#!PersonalAccessTokens:0",
+        )
+        pat = getpass("Your Synapse PAT: ")
+        syn = synapseclient.login(authToken=pat, silent=True)
     return syn
 
 

--- a/portal_tables/utils.py
+++ b/portal_tables/utils.py
@@ -1,4 +1,5 @@
 from getpass import getpass
+from datetime import datetime
 
 import synapseclient
 import pandas as pd
@@ -39,7 +40,17 @@ def convert_to_stringlist(col: pd.Series) -> pd.Series:
 
 
 def update_table(syn: synapseclient.Synapse, table_id: str, df: pd.DataFrame) -> None:
-    """Truncate table then add rows from latest manifest."""
+    """Update the portal table.
+
+    Steps include:
+        - creating a new table version
+        - truncating the table
+        - sync over rows from the latest manifest
+    """
+
+    today = datetime.today().strftime('%Y-%m-%d')
+    print(f"Creating new table version with label: {today}...")
+    syn.create_snapshot_version(table_id, label=today)
 
     print("Syncing table with latest data...\n")
     current_rows = syn.tableQuery(f"SELECT * FROM {table_id}")


### PR DESCRIPTION
Fixes #44 

Depends on #41 

## Changelog

* use print logs similar to `sync_datasets.py` (for consistency)
* call on `utils.update_table()` to perform sync (so that table is truncated before re-adding all the rows from the latest manifest)

## Preview
**Syncing (to a [dummy table](https://www.synapse.org/#!Synapse:syn53642776/tables/))**
<img width="1200" alt="Screenshot 2024-02-21 at 1 08 09 AM" src="https://github.com/mc2-center/mc2-center-dcc/assets/9377970/9eb5feb6-725c-48ce-9361-30430aa65260">

**Dummy table after sync**
<img width="1283" alt="Screenshot 2024-02-21 at 1 08 39 AM" src="https://github.com/mc2-center/mc2-center-dcc/assets/9377970/7b446762-8ab5-4f7d-88fd-5808b0d9c4dc">


