### PR TITLE
Add education sync script

### DIFF
--- a/annotations/gen-mp-csv.py
+++ b/annotations/gen-mp-csv.py
@@ -144,9 +144,13 @@ def main(folder_path, output_csv_file, data_type):
         file_suffix = "_tool.csv"
         folder_id_column_name = "folderIdTools"
 
+    elif data_type == "education":
+        file_suffix = "_education.csv"
+        folder_id_column_name = "folderIdEducation"
+
     else:
         print(
-            "Invalid data type. Please provide one of 'publications', 'datasets', or 'tools'."
+            "Invalid data type. Please provide one of 'publications', 'datasets', 'tools', or 'education'."
         )
         return
 

--- a/annotations/split_manifest_grants.py
+++ b/annotations/split_manifest_grants.py
@@ -97,8 +97,13 @@ def main():
     # manifest as an Excel file.
     manifest = pd.read_csv(args.manifest)
     split_manifests = split_manifest(manifest, manifest_type)
+    
+    if manifest_type == "resource":
+        manifest_type = "education"
+    
     for grant_number in split_manifests.groups:
         df = split_manifests.get_group(grant_number)
+        grant_number = grant_number.translate(str.maketrans("", "", "[]:/!@#$<> "))
         if args.csv:
             path = os.path.join(output_dir, f"{grant_number}_{manifest_type}.csv")
             df.to_csv(path, index=False)

--- a/annotations/split_manifest_grants.py
+++ b/annotations/split_manifest_grants.py
@@ -97,10 +97,10 @@ def main():
     # manifest as an Excel file.
     manifest = pd.read_csv(args.manifest)
     split_manifests = split_manifest(manifest, manifest_type)
-    
+
     if manifest_type == "resource":
         manifest_type = "education"
-    
+
     for grant_number in split_manifests.groups:
         df = split_manifests.get_group(grant_number)
         grant_number = grant_number.translate(str.maketrans("", "", "[]:/!@#$<> "))

--- a/portal_tables/sync_education.py
+++ b/portal_tables/sync_education.py
@@ -1,0 +1,93 @@
+"""Add Educational Resources to the Cancer Complexity Knowledge Portal (CCKP).
+
+This script will "sync" the Educational Resource manifest table to the Educational Resource portal
+table, by first truncating the table, then re-adding the rows.
+"""
+
+import pandas as pd
+import utils
+
+def clean_table(df: pd.DataFrame) -> pd.DataFrame:
+    """Clean up the table one final time."""
+
+    # Convert string columns to string-list.
+    for col in [
+        "ResourceTopic",
+        "ResourceActivityType",
+        "ResourcePrimaryFormat",
+        "ResourceIntendedUse",
+        "ResourcePrimaryAudience",
+        "ResourceEducationalLevel",
+        "ResourceOriginInstitution",
+        "ResourceLanguage",
+        "ResourceContributors",
+        "ResourceGrantNumber",
+        "ResourceSecondaryTopic",
+        "ResourceMediaAccessibility",
+        "ResourceAccessHazard"
+    ]:
+        df[col] = utils.convert_to_stringlist(df[col])
+
+    # Ensure columns match the table order.
+    col_order = [
+        "Component",
+        "ResourceTitle",
+        "ResourceLink",
+        "ResourceTopic",
+        "ResourceActivityType",
+        "ResourcePrimaryFormat",
+        "ResourceIntendedUse",
+        "ResourcePrimaryAudience",
+        "ResourceEducationalLevel",
+        "ResourceDescription",
+        "ResourceOriginInstitution",
+        "ResourceLanguage",
+        "ResourceContributors",
+        "ResourceGrantNumber",
+        "ResourceSecondaryTopic",
+        "ResourceLicense",
+        "ResourceUseRequirements",
+        "ResourceAlias",
+        "ResourceInternalIdentifier",
+        "ResourceMediaAccessibility",
+        "ResourceAccessHazard",
+        "ResourceDatasetAlias",
+        "ResourceToolLink"
+    ]
+    return df[col_order]
+
+
+def main():
+    """Main function."""
+    syn = utils.syn_login()
+    args = utils.get_args("education")
+
+    if args.dryrun:
+        print("\n❗❗❗ WARNING:", "dryrun is enabled (no updates will be done)\n")
+
+    manifest = pd.read_csv(syn.get(args.manifest_id).path).fillna("")
+    manifest.columns = manifest.columns.str.replace(" ", "")
+    if args.verbose:
+        print("🔍 Preview of manifest CSV:\n" + "=" * 72)
+        print(manifest)
+        print()
+
+    print("Processing educational resource staging database...")
+    
+    final_database = clean_table(manifest)
+    if args.verbose:
+        print("\n🔍 Tool(s) to be synced:\n" + "=" * 72)
+        print(final_database)
+        print()
+
+    if not args.dryrun:
+        utils.update_table(syn, args.portal_table_id, final_database)
+        print()
+
+    print(f"📄 Saving copy of final table to: {args.output_csv}...")
+    final_database.to_csv(args.output_csv, index=False)
+    print("\n\nDONE ✅")
+
+
+if __name__ == "__main__":
+    main()

--- a/portal_tables/sync_education.py
+++ b/portal_tables/sync_education.py
@@ -77,7 +77,7 @@ def main():
 
     final_database = clean_table(manifest)
     if args.verbose:
-        print("\n🔍 Tool(s) to be synced:\n" + "=" * 72)
+        print("\n🔍 Educational resource(s) to be synced:\n" + "=" * 72)
         print(final_database)
         print()
 

--- a/portal_tables/sync_education.py
+++ b/portal_tables/sync_education.py
@@ -7,6 +7,7 @@ table, by first truncating the table, then re-adding the rows.
 import pandas as pd
 import utils
 
+
 def clean_table(df: pd.DataFrame) -> pd.DataFrame:
     """Clean up the table one final time."""
 
@@ -24,7 +25,7 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "ResourceGrantNumber",
         "ResourceSecondaryTopic",
         "ResourceMediaAccessibility",
-        "ResourceAccessHazard"
+        "ResourceAccessHazard",
     ]:
         df[col] = utils.convert_to_stringlist(df[col])
 
@@ -52,7 +53,7 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "ResourceMediaAccessibility",
         "ResourceAccessHazard",
         "ResourceDatasetAlias",
-        "ResourceToolLink"
+        "ResourceToolLink",
     ]
     return df[col_order]
 
@@ -73,7 +74,7 @@ def main():
         print()
 
     print("Processing educational resource staging database...")
-    
+
     final_database = clean_table(manifest)
     if args.verbose:
         print("\n🔍 Tool(s) to be synced:\n" + "=" * 72)

--- a/portal_tables/utils.py
+++ b/portal_tables/utils.py
@@ -25,6 +25,7 @@ CONFIG = {
     },
     "people": {"manifest": "syn38301033", "portal_table": "syn28073190"},
     "grant": {"manifest": "syn53259587", "portal_table": "syn21918972"},
+    "education": {"manifest": "syn53651540", "portal_table": "syn51497305"}
 }
 
 

--- a/portal_tables/utils.py
+++ b/portal_tables/utils.py
@@ -11,21 +11,12 @@ import pandas as pd
 
 # Manifest and portal table synIDs of each resource type.
 CONFIG = {
-    "publication": {
-        "manifest": "syn53478776",
-        "portal_table": "syn21868591",
-    },
-    "dataset": {
-        "manifest": "syn53478774",
-        "portal_table": "syn21897968",
-    },
-    "tool": {
-        "manifest": "syn53479671",
-        "portal_table": "syn26127427",
-    },
+    "publication": {"manifest": "syn53478776", "portal_table": "syn21868591"},
+    "dataset": {"manifest": "syn53478774", "portal_table": "syn21897968"},
+    "tool": {"manifest": "syn53479671", "portal_table": "syn26127427"},
     "people": {"manifest": "syn38301033", "portal_table": "syn28073190"},
     "grant": {"manifest": "syn53259587", "portal_table": "syn21918972"},
-    "education": {"manifest": "syn53651540", "portal_table": "syn51497305"}
+    "education": {"manifest": "syn53651540", "portal_table": "syn51497305"},
 }
 
 


### PR DESCRIPTION
Adds sync_education.py, based on sync_tools.py
Adds education info to CONFIG in utils.py

Output with '-v' and '--dryrun' flags:
<img width="1062" alt="Screenshot 2024-02-22 at 3 17 17 PM" src="https://github.com/mc2-center/mc2-center-dcc/assets/49208907/ad21851b-18d8-4836-b304-99a5cca6fbe5">

Output with '--dryrun' flag only:
<img width="512" alt="Screenshot 2024-02-22 at 3 20 35 PM" src="https://github.com/mc2-center/mc2-center-dcc/assets/49208907/275349f8-7925-4341-b3a6-d9370f7842a1">

Terminal from upload to dummy table:

<img width="847" alt="Screenshot 2024-02-22 at 3 32 55 PM" src="https://github.com/mc2-center/mc2-center-dcc/assets/49208907/c0cf4526-fa72-4183-a34f-c08b7f807401">


Resulting dummy table:
<img width="1694" alt="Screenshot 2024-02-22 at 3 33 28 PM" src="https://github.com/mc2-center/mc2-center-dcc/assets/49208907/712c66d7-cf07-47d6-a135-26b8a44ab04e">
