### PR TITLE
RePORTER query scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 great_expectations/
 .vscode/
 outputs/
+upload_check*
+*manifests/

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 **/.DS_Store
 great_expectations/
 .vscode/
+outputs/

--- a/utils/clean_reporter_results.py
+++ b/utils/clean_reporter_results.py
@@ -20,32 +20,30 @@ def get_args():
 
 def extract_for_filtering(report_df):
 
-    grant_pattern = re.compile("CA\d{6}")
-    year_pattern = re.compile("(?:-(\d{2}))")
-    report_df["main_grant"] = ""
-    report_df["grant_year"] = ""
-    for _, row in report_df.iterrows():
-        extracted_grants = []
-        extracted_year = []
-        base_grant = grant_pattern.findall(row["project_num"])
-        grant_year = year_pattern.findall(row["project_num"])
-        extracted_grants.append(base_grant[0])
-        extracted_year.append(grant_year[0])
-        report_df.at[_, "main_grant"] = extracted_grants[0]
-        report_df.at[_, "grant_year"] = extracted_year[0]
+    column_info = [("grant", "CA\d{6}", "project_num"), ("year", "(?:-(\d{2}))", "project_num")]
+    for tup in column_info:
+        col_name = "_".join([tup[0], "num"])
+        extract_name = "_".join([tup[0], "extracted"])
+        pattern = re.compile(tup[1])
+        report_df[col_name] = ""
+        for _, row in report_df.iterrows():
+            extract_name = []
+            extract = pattern.findall(row[tup[2]])
+            extract_name.append(extract[0])
+            report_df.at[_, col_name] = extract_name[0]
     return report_df
 
 
 def filter_report(report):
 
-    groups = report.groupby(["main_grant", "grant_year"], as_index=False)
+    groups = report.groupby(["grant_num", "year_num"], as_index=False)
     max_year_table = report.loc[
-        report.groupby(["main_grant"])["grant_year"].idxmax()
-    ].sort_values(by=["main_grant", "grant_year"])
+        report.groupby(["grant_num"])["year_num"].idxmax()
+    ].sort_values(by=["grant_num", "year_num"])
     entries_to_keep = []
     for _, row in max_year_table.iterrows():
-        g = row["grant_year"]
-        n = row["main_grant"]
+        g = row["year_num"]
+        n = row["grant_num"]
         for name, group in groups:
             if name[0] == n and name[1] == g:
                 entries_to_keep.append(group)

--- a/utils/clean_reporter_results.py
+++ b/utils/clean_reporter_results.py
@@ -1,0 +1,79 @@
+import argparse
+import pandas as pd
+import re
+
+
+def get_args():
+
+    parser = argparse.ArgumentParser(
+        description="Access and validate tables from Synapse"
+    )
+    parser.add_argument(
+        "-r",
+        nargs="+",
+        help="List of paths to CSVs containing reporter entries from import_json.py",
+    )
+    parser.add_argument("-c", help="Path for CSV where parsed report will be stored.")
+
+    return parser.parse_args()
+
+
+def extract_for_filtering(report_df):
+
+    grant_pattern = re.compile("CA\d{6}")
+    year_pattern = re.compile("(?:-(\d{2}))")
+    report_df["main_grant"] = ""
+    report_df["grant_year"] = ""
+    for _, row in report_df.iterrows():
+        extracted_grants = []
+        extracted_year = []
+        base_grant = grant_pattern.findall(row["project_num"])
+        grant_year = year_pattern.findall(row["project_num"])
+        extracted_grants.append(base_grant[0])
+        extracted_year.append(grant_year[0])
+        report_df.at[_, "main_grant"] = extracted_grants[0]
+        report_df.at[_, "grant_year"] = extracted_year[0]
+    return report_df
+
+
+def filter_report(report):
+
+    groups = report.groupby(["main_grant", "grant_year"], as_index=False)
+    max_year_table = report.loc[
+        report.groupby(["main_grant"])["grant_year"].idxmax()
+    ].sort_values(by=["main_grant", "grant_year"])
+    entries_to_keep = []
+    for _, row in max_year_table.iterrows():
+        g = row["grant_year"]
+        n = row["main_grant"]
+        for name, group in groups:
+            if name[0] == n and name[1] == g:
+                entries_to_keep.append(group)
+                print(f"{name} matches {n} and {g} - added to entry list")
+    filtered_report = pd.concat(entries_to_keep).reset_index(drop=True).drop_duplicates()
+
+    return filtered_report
+
+
+def main():
+    args = get_args()
+
+    reports, csvPath = args.r, args.c
+
+    report_list = []
+
+    for report in reports:
+        report_df = pd.read_csv(report, dtype={"subproject_id": "str"})
+        report_list.append(report_df)
+
+    full_report = pd.concat(report_list).reset_index(drop=True)
+
+    report_to_filter = extract_for_filtering(full_report)
+
+    final_report = filter_report(report_to_filter)
+
+    final_report.to_csv(csvPath, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/reporter_project_query.py
+++ b/utils/reporter_project_query.py
@@ -109,7 +109,7 @@ def main():
         grant_chunks = [g.tolist() for g in np.array_split(grants, split_count)]
 
     else:
-        grant_chunks = grants
+        grant_chunks = [grants]
 
     all_reports = []
 
@@ -139,7 +139,6 @@ def main():
             print(json_report)
 
     build_report(all_reports, csvPath)
-
 
 if __name__ == "__main__":
     main()

--- a/utils/reporter_project_query.py
+++ b/utils/reporter_project_query.py
@@ -1,0 +1,158 @@
+import json
+import argparse
+import requests
+import numpy as np
+import math
+import pandas as pd
+
+
+def get_args():
+
+    parser = argparse.ArgumentParser(
+        description="Access and validate tables from Synapse"
+    )
+    parser.add_argument(
+        "-g",
+        nargs="+",
+        help="Space separated list of grant numbers to query NIH RePORTER",
+    )
+    parser.add_argument(
+        "-y",
+        nargs="+",
+        default=[],
+        help="The list of years to use when searching for grant information.",
+    )
+    parser.add_argument("-c", help="Path for CSV where converted JSON will be stored.")
+
+    return parser.parse_args()
+
+
+def build_payload(grant_numbers, years, lim):
+
+    criteria_dict = dict(
+        project_nums=grant_numbers, sub_project_only=True, fiscal_years=years
+    )
+
+    include = [
+        "ProjectTitle",
+        "ProjectNum",
+        "SubprojectId",
+        "FiscalYear",
+        "ProjectEndDate",
+    ]
+
+    payload = dict(
+        criteria=criteria_dict,
+        include_fields=include,
+        offset=0,
+        limit=lim,
+        sort_field="fiscal_year",
+        sort_order="desc",
+    )
+
+    json_payload = json.dumps(payload)
+
+    return json_payload
+
+
+def get_reporter_info(search_payload, header_content):
+
+    req = requests.post(
+        url="https://api.reporter.nih.gov/v2/projects/search",
+        headers=header_content,
+        data=search_payload,
+    )
+
+    return req
+
+
+def build_report(report_list, out_path):
+
+    df_list = []
+    for report in report_list:
+        report_df = pd.read_json(report, orient="records")
+        df_list.append(report_df)
+
+    full_report = pd.concat(df_list).reset_index(drop=True)
+
+    print(f"\n\nYour report is available at {out_path}.\n\n")
+
+    full_report.to_csv(out_path, index=False)
+
+
+def main():
+
+    args = get_args()
+
+    in_grants, in_years, csvPath = args.g, args.y, args.c
+
+    grants = []
+
+    years = []
+
+    for grant in in_grants:
+        grant = "".join([grant, "*"])
+        grants.append(grant)
+
+    for year in in_years:
+        year = int(year)
+        years.append(year)
+
+    headers = {"content-type": "application/json"}
+
+    max_request_length = int(400)
+    grant_count = int(len(grants))
+    req_per_grant = int(20)
+
+    if grant_count > max_request_length / req_per_grant:
+        split_count = math.ceil(grant_count / req_per_grant) + 1
+        print(
+            f"Due to API restrictions, your query will be split into {split_count} parts"
+        )
+        grant_chunks = [g.tolist() for g in np.array_split(grants, split_count)]
+
+    else:
+        grant_chunks = grants
+
+    all_reports = []
+
+    for grant_list in grant_chunks:
+
+        print(f"Building your RePORTER query...")
+        query = build_payload(
+            grant_numbers=grant_list, years=years, lim=max_request_length
+        )
+        valid = json.loads(query)
+
+        if valid:
+            print(f"\n\nSUCCESS! Your query was converted to a valid JSON string")
+
+        else:
+            print(
+                f"\n\nNot quite! Your query: \n {query} \n is an invalid JSON string.\nPlease revise your query and try again."
+            )
+            break
+
+        print(f"\n\nSubmitting your query to RePORTER...")
+        report = get_reporter_info(query, headers)
+        status = report.status_code
+        
+        if status == 200:
+            print(
+                f"\n\nSUCCESS! Reply included a {report.status_code} status code!\n\nBuilding report from results..."
+            )
+            json_report = report.json()
+            json_report = json.dumps(json_report["results"])
+            all_reports.append(json_report)
+
+        else:
+            print(
+                f"Not quite! Reply included a {report.status_code} status code. Please review the response to diagnose the error.\n\n"
+            )
+            print(json_report)
+
+    build_report(all_reports, csvPath)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/reporter_project_query.py
+++ b/utils/reporter_project_query.py
@@ -90,13 +90,9 @@ def main():
 
     years = []
 
-    for grant in in_grants:
-        grant = "".join([grant, "*"])
-        grants.append(grant)
+    grants = [g + "*" for g in in_grants]
 
-    for year in in_years:
-        year = int(year)
-        years.append(year)
+    years = [int(y) for y in in_years]
 
     headers = {"content-type": "application/json"}
 

--- a/utils/reporter_project_query.py
+++ b/utils/reporter_project_query.py
@@ -4,6 +4,7 @@ import requests
 import numpy as np
 import math
 import pandas as pd
+from io import StringIO
 
 
 def get_args():
@@ -71,7 +72,7 @@ def build_report(report_list, out_path):
 
     df_list = []
     for report in report_list:
-        report_df = pd.read_json(report, orient="records")
+        report_df = pd.read_json(StringIO(report), orient="records")
         df_list.append(report_df)
 
     full_report = pd.concat(df_list).reset_index(drop=True)

--- a/utils/reporter_project_query.py
+++ b/utils/reporter_project_query.py
@@ -9,7 +9,7 @@ import pandas as pd
 def get_args():
 
     parser = argparse.ArgumentParser(
-        description="Access and validate tables from Synapse"
+        description="Query NIH RePORTER for grant information and return as a CSV"
     )
     parser.add_argument(
         "-g",
@@ -51,6 +51,7 @@ def build_payload(grant_numbers, years, lim):
     )
 
     json_payload = json.dumps(payload)
+    print(f"\n\nSUCCESS! Your query was converted to a valid JSON string")
 
     return json_payload
 
@@ -118,16 +119,6 @@ def main():
         query = build_payload(
             grant_numbers=grant_list, years=years, lim=max_request_length
         )
-        valid = json.loads(query)
-
-        if valid:
-            print(f"\n\nSUCCESS! Your query was converted to a valid JSON string")
-
-        else:
-            print(
-                f"\n\nNot quite! Your query: \n {query} \n is an invalid JSON string.\nPlease revise your query and try again."
-            )
-            break
 
         print(f"\n\nSubmitting your query to RePORTER...")
         report = get_reporter_info(query, headers)


### PR DESCRIPTION
This PR adds two scripts that can be used for collecting grant information from the [NIH RePORTER API](https://api.reporter.nih.gov/):
- reporter_project_query.py: queries the RePORTER API projects endpoint for grant information and returns the results as a CSV
- clean_reporter_results.py: takes the CSV from RePORTER, removes outdated and redundant entries, and returns a CSV

While the scripts were designed for the specific purpose of collecting subproject_id values, the input arguments and JSON payload content in reporter_project_query.py can be modified to capture other information available from the RePORTER API. The extractions and filtering criteria in clean_reporter_results.py can also be adjusted, if needed. As such, I imagine these scripts can be extended to capture most or all of the GrantView and ProjectView metadata we record.