### PR TITLE
Script updates - issue 58

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 **/.DS_Store
 great_expectations/
 .vscode/
+upload_check*

--- a/annotations/schema_update.py
+++ b/annotations/schema_update.py
@@ -69,7 +69,34 @@ columns_to_modify = [
     f"{entity_type} File Formats",
     f"{entity_type} Year",
     f"{entity_type} Accessibility",
-    f"{entity_type}View_id"
+    f"{entity_type}View_id",
+    f"{entity_type} Homepage",
+    f"{entity_type} Version",
+    f"{entity_type} Operation",
+    f"{entity_type} Input Data",
+    f"{entity_type} Output Data",
+    f"{entity_type} Input Format",
+    f"{entity_type} Output Format",
+    f"{entity_type} Function Note",
+    f"{entity_type} Cmd",
+    f"{entity_type} Type",
+    f"{entity_type} Topic",
+    f"{entity_type} Operating System",
+    f"{entity_type} Language",
+    f"{entity_type} License",
+    f"{entity_type} Cost",
+    f"{entity_type} Download Url",
+    f"{entity_type} Download Type",
+    f"{entity_type} Download Note",
+    f"{entity_type} Download Version",
+    f"{entity_type} Documentation Url",
+    f"{entity_type} Documentation Type",
+    f"{entity_type} Documentation Note",
+    f"{entity_type} Link Url",
+    f"{entity_type} Link Type",
+    f"{entity_type} Link Note",
+    f"Id",
+    f"entityId"
 ]
 
 # Initialize counter
@@ -91,26 +118,73 @@ for my_table_synid in table_ids_list:
 
             if column_to_modify:
                 # Set columnType and maximumSize accordingly
-                if column_name in [f"{entity_type} Abstract", f"{entity_type} Authors", f"{entity_type} Description", f"{entity_type} Design"]:
+                if column_name in [
+                    f"{entity_type} Abstract",
+                    f"{entity_type} Authors",
+                    f"{entity_type} Description",
+                    f"{entity_type} Design",
+                    f"{entity_type} Function Note",
+                    f"{entity_type} Download Note",
+                    f"{entity_type} Documentation Note",
+                    f"{entity_type} Link Note"
+                ]:
                     new_column = syn.store(
-                        synapseclient.Column(
-                            name=column_name, columnType="LARGETEXT"
-                        )
+                        synapseclient.Column(name=column_name, columnType="LARGETEXT")
                     )
-                elif column_name in [f"{entity_type} Keywords", f"{entity_type} Title", f"{entity_type} Assay"]:
+                elif column_name in [
+                    f"{entity_type} Keywords",
+                    f"{entity_type} Title",
+                    f"{entity_type} Assay",
+                    f"{entity_type} Cmd",
+                    f"{entity_type} Documentation Type",
+                    f"{entity_type} Link Type"
+                ]:
                     new_column = syn.store(
-                        synapseclient.Column(
-                            name=column_name, columnType="MEDIUMTEXT"
-                        )
+                        synapseclient.Column(name=column_name, columnType="MEDIUMTEXT")
                     )
 
-                elif column_name in [f"{entity_type} Name", f"{entity_type} Alias", f"{entity_type} Species", f"{entity_type} Tumor Type", f"{entity_type} Tissue", f"{entity_type} Dataset Alias", f"{entity_type} Url", f"{entity_type} File Formats"]:
+                elif column_name in [
+                    f"{entity_type} Name",
+                    f"{entity_type} Alias",
+                    f"{entity_type} Species",
+                    f"{entity_type} Tumor Type",
+                    f"{entity_type} Tissue",
+                    f"{entity_type} Dataset Alias",
+                    f"{entity_type} Url",
+                    f"{entity_type} File Formats",
+                    f"{entity_type} Homepage",
+                    f"{entity_type} Operation",
+                    f"{entity_type} Input Data",
+                    f"{entity_type} Output Data",
+                    f"{entity_type} Input Format",
+                    f"{entity_type} Output Format",
+                    f"{entity_type} Download Type",
+                    f"{entity_type} Type",
+                    f"{entity_type} Topic",
+                    f"{entity_type} Download Url",
+                    f"{entity_type} Documentation Url",
+                    f"{entity_type} Link Url"
+                ]:
                     new_column = syn.store(
                         synapseclient.Column(
                             name=column_name, columnType="STRING", maximumSize=500
                         )
                     )
                 
+                elif column_name == f"Id":
+                    new_column = syn.store(
+                        synapseclient.Column(
+                            name=column_name, columnType="STRING", maximumSize=64
+                        )
+                    )
+                
+                elif column_name == f"entityId":
+                    new_column = syn.store(
+                        synapseclient.Column(
+                            name=column_name, columnType="STRING", maximumSize=30
+                        )
+                    )
+
                 else:
                     new_column = syn.store(
                         synapseclient.Column(

--- a/annotations/schema_update.py
+++ b/annotations/schema_update.py
@@ -59,6 +59,14 @@ columns_to_modify = [
     f"{entity_type} Journal",
     f"Pubmed Id",
     f"Pubmed Url",
+    f"{entity_type} Name",
+    f"{entity_type} Pubmed Id",
+    f"{entity_type} Alias",
+    f"{entity_type} Description",
+    f"{entity_type} Design",
+    f"{entity_type} Species",
+    f"{entity_type} Url",
+    f"{entity_type} File Formats",
     f"{entity_type} Year",
     f"{entity_type} Accessibility",
     f"{entity_type}View_id"
@@ -83,7 +91,7 @@ for my_table_synid in table_ids_list:
 
             if column_to_modify:
                 # Set columnType and maximumSize accordingly
-                if column_name in [f"{entity_type} Abstract", f"{entity_type} Authors"]:
+                if column_name in [f"{entity_type} Abstract", f"{entity_type} Authors", f"{entity_type} Description", f"{entity_type} Design"]:
                     new_column = syn.store(
                         synapseclient.Column(
                             name=column_name, columnType="LARGETEXT"
@@ -96,7 +104,7 @@ for my_table_synid in table_ids_list:
                         )
                     )
 
-                elif column_name in [f"{entity_type} Tumor Type", f"{entity_type} Tissue", f"{entity_type} Dataset Alias"]:
+                elif column_name in [f"{entity_type} Name", f"{entity_type} Alias", f"{entity_type} Species", f"{entity_type} Tumor Type", f"{entity_type} Tissue", f"{entity_type} Dataset Alias", f"{entity_type} Url", f"{entity_type} File Formats"]:
                     new_column = syn.store(
                         synapseclient.Column(
                             name=column_name, columnType="STRING", maximumSize=500

--- a/annotations/schema_update.py
+++ b/annotations/schema_update.py
@@ -83,20 +83,20 @@ for my_table_synid in table_ids_list:
 
             if column_to_modify:
                 # Set columnType and maximumSize accordingly
-                if column_name == f"{entity_type} Abstract":
+                if column_name in [f"{entity_type} Abstract", f"{entity_type} Authors"]:
                     new_column = syn.store(
                         synapseclient.Column(
                             name=column_name, columnType="LARGETEXT"
                         )
                     )
-                elif column_name in [f"{entity_type} Authors", f"{entity_type} Keywords", f"{entity_type} Title", f"{entity_type} Assay"]:
+                elif column_name in [f"{entity_type} Keywords", f"{entity_type} Title", f"{entity_type} Assay"]:
                     new_column = syn.store(
                         synapseclient.Column(
                             name=column_name, columnType="MEDIUMTEXT"
                         )
                     )
 
-                elif column_name in [f"{entity_type} Tumor Type", f"{entity_type} Tissue"]:
+                elif column_name in [f"{entity_type} Tumor Type", f"{entity_type} Tissue", f"{entity_type} Dataset Alias"]:
                     new_column = syn.store(
                         synapseclient.Column(
                             name=column_name, columnType="STRING", maximumSize=500

--- a/annotations/schema_update.py
+++ b/annotations/schema_update.py
@@ -44,7 +44,6 @@ print(table_ids_list)
 # Updating schema for all the tables in the list
 # Columns to modify
 columns_to_modify = [
-    "Component",
     f"{entity_type} Keywords",
     f"{entity_type} Abstract",
     f"{entity_type} Authors",
@@ -55,6 +54,14 @@ columns_to_modify = [
     f"{entity_type} Title",
     f"{entity_type} Download Type",
     f"{entity_type} Documentation Type",
+    f"{entity_type} Grant Number",
+    f"{entity_type} Doi",
+    f"{entity_type} Journal",
+    f"Pubmed Id",
+    f"Pubmed Url",
+    f"{entity_type} Year",
+    f"{entity_type} Accessibility",
+    f"{entity_type}View_id"
 ]
 
 # Initialize counter
@@ -79,13 +86,27 @@ for my_table_synid in table_ids_list:
                 if column_name == f"{entity_type} Abstract":
                     new_column = syn.store(
                         synapseclient.Column(
-                            name=column_name, columnType="LARGETEXT", maximumSize=500
+                            name=column_name, columnType="LARGETEXT"
                         )
                     )
-                else:
+                elif column_name in [f"{entity_type} Authors", f"{entity_type} Keywords", f"{entity_type} Title", f"{entity_type} Assay"]:
+                    new_column = syn.store(
+                        synapseclient.Column(
+                            name=column_name, columnType="MEDIUMTEXT"
+                        )
+                    )
+
+                elif column_name in [f"{entity_type} Tumor Type", f"{entity_type} Tissue"]:
                     new_column = syn.store(
                         synapseclient.Column(
                             name=column_name, columnType="STRING", maximumSize=500
+                        )
+                    )
+                
+                else:
+                    new_column = syn.store(
+                        synapseclient.Column(
+                            name=column_name, columnType="STRING", maximumSize=100
                         )
                     )
 

--- a/annotations/split_manifest_grants.py
+++ b/annotations/split_manifest_grants.py
@@ -66,6 +66,8 @@ def split_manifest(df, manifest_type):
 
     df[colname] = df[colname].str.split(", ")
 
+    df = df.drop(["entityId"], axis=1, errors="ignore")
+
     grouped = df.explode(colname).groupby(colname)
     print(f"Found {len(grouped.groups)} grant numbers in table " "- splitting now...")
     return grouped

--- a/annotations/upload-manifests.py
+++ b/annotations/upload-manifests.py
@@ -63,13 +63,13 @@ def validate_entry_worker(args, cf, mt, valid_only):
         "-dt",
         mt,
         "-mp",
-        fp,
+        fp
     ]
 
     print(f"Running validation command: {' '.join(validate_command)}")
     try:
         subprocess.run(
-            validate_command, shell=True, check=True, stdout=sys.stdout, stderr=subprocess.STDOUT
+            validate_command, check=True, stdout=sys.stdout, stderr=subprocess.STDOUT
         )
         return args  # Validation succeeded, return the tuple
     except subprocess.CalledProcessError:
@@ -93,17 +93,18 @@ def submit_entry_worker(args, cf):
         fp,
         "-d",
         target_id,
-        "-dl",
         "-mrt",
         "table_and_file",
         "-tm",
         "upsert",
+        "-tcn",
+        "display_name"
     ]
     cmd_line = " ".join(command)
 
     print(cmd_line)
 
-    subprocess.run(command, shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
+    subprocess.run(command, stdout=sys.stdout, stderr=subprocess.STDOUT)
 
 
 def main():

--- a/annotations/upload-manifests.py
+++ b/annotations/upload-manifests.py
@@ -69,7 +69,7 @@ def validate_entry_worker(args, cf, mt, valid_only):
     print(f"Running validation command: {' '.join(validate_command)}")
     try:
         subprocess.run(
-            validate_command, check=True, stdout=sys.stdout, stderr=subprocess.STDOUT
+            validate_command, shell=True, check=True, stdout=sys.stdout, stderr=subprocess.STDOUT
         )
         return args  # Validation succeeded, return the tuple
     except subprocess.CalledProcessError:
@@ -103,7 +103,7 @@ def submit_entry_worker(args, cf):
 
     print(cmd_line)
 
-    subprocess.run(command, stdout=sys.stdout, stderr=subprocess.STDOUT)
+    subprocess.run(command, shell=True, stdout=sys.stdout, stderr=subprocess.STDOUT)
 
 
 def main():

--- a/utils/union_qc.py
+++ b/utils/union_qc.py
@@ -159,7 +159,7 @@ def combine_rows(args):
 
                     mapping = {
                         componentColumn: "first",
-                        idColumn: ",".join,
+                        idColumn: "first",
                         "Dataset Pubmed Id": "first",
                         grantColumn: ",".join,
                         "Dataset Name": "first",
@@ -180,7 +180,7 @@ def combine_rows(args):
 
                 mapping = {
                     componentColumn: "first",
-                    idColumn: ",".join,
+                    idColumn: "first",
                     "Tool Pubmed Id": "first",
                     grantColumn: ",".join,
                     "Tool Description": "first",
@@ -219,7 +219,7 @@ def combine_rows(args):
 
             mapping = {
                 componentColumn: "first",
-                idColumn: ",".join,
+                idColumn: "first",
                 "Resource Title": "first",
                 "Resource Link": "first",
                 "Resource Topic": "first",
@@ -319,7 +319,15 @@ def compare_and_subset_tables(args):
 
         elif name == "ToolView":
             key = ["Tool Name"]
-            cols = ["Tool Name", "ToolView_id", "Tool Type", "Tool Topic", "Tool Language", "Tool Documentation Url","Tool Documentation Type"]
+            cols = [
+                "Tool Name",
+                "ToolView_id",
+                "Tool Type",
+                "Tool Topic",
+                "Tool Language",
+                "Tool Documentation Url",
+                "Tool Documentation Type",
+            ]
 
         elif name == "EducationalResource":
             key = ["Resource Alias"]

--- a/utils/union_qc.py
+++ b/utils/union_qc.py
@@ -135,7 +135,7 @@ def combine_rows(args):
 
                     mapping = {  # defines how info in each column is handled by row merging function
                         componentColumn: "first",
-                        idColumn: "first",
+                        idColumn: ",".join,
                         grantColumn: ",".join,
                         "Publication Doi": "first",
                         "Publication Journal": "first",
@@ -159,7 +159,7 @@ def combine_rows(args):
 
                     mapping = {
                         componentColumn: "first",
-                        idColumn: "first",
+                        idColumn: ",".join,
                         "Dataset Pubmed Id": "first",
                         grantColumn: ",".join,
                         "Dataset Name": "first",
@@ -180,7 +180,7 @@ def combine_rows(args):
 
                 mapping = {
                     componentColumn: "first",
-                    idColumn: "first",
+                    idColumn: ",".join,
                     "Tool Pubmed Id": "first",
                     grantColumn: ",".join,
                     "Tool Description": "first",
@@ -219,7 +219,7 @@ def combine_rows(args):
 
             mapping = {
                 componentColumn: "first",
-                idColumn: "first",
+                idColumn: ",".join,
                 "Resource Title": "first",
                 "Resource Link": "first",
                 "Resource Topic": "first",
@@ -303,9 +303,11 @@ def compare_and_subset_tables(args):
             key = ["Pubmed Id"]
             cols = [
                 "Pubmed Id",
+                "Pubmed Url",
                 "Publication Assay",
                 "Publication Tissue",
                 "Publication Tumor Type",
+                "Publication Accessibility"
             ]
 
         elif name == "DatasetView":
@@ -315,6 +317,9 @@ def compare_and_subset_tables(args):
                 "Dataset Assay",
                 "Dataset Tissue",
                 "Dataset Tumor Type",
+                "Dataset File Formats",
+                "Dataset Url",
+                "Dataset Species"
             ]
 
         elif name == "ToolView":

--- a/utils/union_qc.py
+++ b/utils/union_qc.py
@@ -256,7 +256,31 @@ def combine_rows(args):
 
     return list(zip(groups, names))
 
+def get_ref_tables(syn, names):
 
+    ref_paths = []
+    
+    for name in names:
+
+        if name == "PublicationView":
+            ref = "syn53478776"
+        
+        elif name == "DatasetView":
+            ref = "syn53478774"
+
+        elif name == "ToolView":
+            ref = "syn53479671"
+
+        elif name == "EducationalResource":
+            ref = "syn53651540"
+
+        ref_table = syn.get(ref, downloadLocation="./output")
+        ref_paths.append(ref_table.path)
+
+    return ref_paths
+
+def compare_and_subset_tables(current, new):
+        
 def validate_tables(args, config):
 
     paths, names = zip(*args)

--- a/utils/union_qc.py
+++ b/utils/union_qc.py
@@ -319,9 +319,11 @@ def compare_and_subset_tables(args):
 
         elif name == "ToolView":
             key = ["Tool Name"]
+            cols = ["Tool Name", "ToolView_id", "Tool Type", "Tool Topic", "Tool Language", "Tool Documentation Url","Tool Documentation Type"]
 
         elif name == "EducationalResource":
             key = ["Resource Alias"]
+            cols = ["Resource Alias", "EducationalResource_id"]
 
         current_table = pd.read_csv(ref, header=0).sort_values(by=key)
         new_table = pd.read_csv(new, header=0).sort_values(by=key)

--- a/utils/union_qc.py
+++ b/utils/union_qc.py
@@ -2,7 +2,8 @@
 union_qc.py
 
 Submits a query to get all information from a Synapse table
-Validates table entries against a schematic data model
+Checks new Synapse table against current CCKP database entries and reports non-matching entries
+Validates non-matching table entries against a schematic data model
 Returns row identifer and validation state
 Trims invalid entries using schematic error log
 
@@ -71,7 +72,9 @@ def get_tables(syn, tableIdList, mergeFlag):
             1, 0
         ]  # grab name of data type from table; assumes "Component" is first column in table
 
-        manifestPath = Path(f"output/{name}/{name}.csv")  # build path to store table as CSV
+        manifestPath = Path(
+            f"output/{name}/{name}.csv"
+        )  # build path to store table as CSV
         manifestPath.parent.mkdir(
             parents=True, exist_ok=True
         )  # create folder to store CSVs
@@ -256,6 +259,7 @@ def combine_rows(args):
 
     return list(zip(groups, names))
 
+
 def get_ref_tables(syn, args):
 
     tables, names = zip(*args)
@@ -263,12 +267,12 @@ def get_ref_tables(syn, args):
     ref_paths = []
     table_paths = []
     ref_names = []
-    
+
     for table, name in zip(tables, names):
 
         if name == "PublicationView":
             ref = "syn53478776"
-        
+
         elif name == "DatasetView":
             ref = "syn53478774"
 
@@ -285,6 +289,7 @@ def get_ref_tables(syn, args):
 
     return list(zip(ref_paths, table_paths, ref_names))
 
+
 def compare_and_subset_tables(args):
 
     current, updated, names = zip(*args)
@@ -296,11 +301,21 @@ def compare_and_subset_tables(args):
 
         if name == "PublicationView":
             key = ["Pubmed Id"]
-            cols = ["Pubmed Id", "Publication Assay", "Publication Tissue", "Publication Tumor Type"]
-        
+            cols = [
+                "Pubmed Id",
+                "Publication Assay",
+                "Publication Tissue",
+                "Publication Tumor Type",
+            ]
+
         elif name == "DatasetView":
             key = ["Dataset Alias"]
-            cols = ["Dataset Alias", "Dataset Assay", "Dataset Tissue", "Dataset Tumor Type"]
+            cols = [
+                "Dataset Alias",
+                "Dataset Assay",
+                "Dataset Tissue",
+                "Dataset Tumor Type",
+            ]
 
         elif name == "ToolView":
             key = ["Tool Name"]
@@ -314,8 +329,10 @@ def compare_and_subset_tables(args):
         tables = [current_table, new_table]
 
         updated = pd.concat(tables, ignore_index=True).reset_index(drop=True)
-        updated.drop_duplicates(subset=cols, keep=False, ignore_index=True, inplace=True)
-        
+        updated.drop_duplicates(
+            subset=cols, keep=False, ignore_index=True, inplace=True
+        )
+
         updatePath = Path(f"output/{name}/{name}_updated.csv")
         updatePath.parent.mkdir(parents=True, exist_ok=True)
 
@@ -323,8 +340,9 @@ def compare_and_subset_tables(args):
 
         updatePaths.append(updatePath)
         updateNames.append(name)
-    
+
     return list(zip(updatePaths, updateNames))
+
 
 def validate_tables(args, config):
 
@@ -493,7 +511,7 @@ def main():
 
         else:
             print("\n\nValidating unmerged manifest(s)...")
-        
+
         refTables = get_ref_tables(syn, newTables)
 
         updatedTables = compare_and_subset_tables(refTables)

--- a/utils/union_qc.py
+++ b/utils/union_qc.py
@@ -435,6 +435,7 @@ def trim_tables(args):
 def main():
 
     args = get_args()
+    syn = login()
 
     inputList, config, trimList, inputManifest, merge, trim = (
         args.l,
@@ -449,8 +450,6 @@ def main():
 
         if inputManifest is None:
             print("Accessing requested tables...")
-
-            syn = login()
 
             newTables = get_tables(syn, inputList, merge)
             print(
@@ -490,12 +489,14 @@ def main():
         else:
             print("\n\nValidating unmerged manifest(s)...")
         
-        
+        refTables = get_ref_tables(syn, newTables)
 
-        checkTables = validate_tables(newTables, config)
+        updatedTables = compare_and_subset_tables(refTables)
+
+        checkTables = validate_tables(updatedTables, config)
         print("\n\nValidation logs stored in local output folder!")
 
-        print("\n\nConverting validation logs to create reference tables...")
+        print("\n\nConverting validation logs to trim config files...")
 
         print(checkTables)
 


### PR DESCRIPTION
This PR collects script changes and additions made while correcting and backpopulating CCKP metadata to grant-based Synapse projects

- union_qc.py: Add function to pull existing table CSVs from Synapse, based on input manifest data types
- union_qc.py: Add function to subset new union table into non-matching entries, based on current CSV in Synapse. Subset/updates are sent to validation function
- union_qc.py: Implement second level of output organization in file path definitions
- update_schema.py: Add additional PublicationView, DatasetView, and ToolView column labels
- update_schema.py: Add table schema mappings for new columns 