### PR TITLE
159-part2-iconTags

### DIFF
--- a/portal_tables/build_tag_lists.py
+++ b/portal_tables/build_tag_lists.py
@@ -1,0 +1,86 @@
+"""
+Parse annotations and identify tag terms to associate with portal entries.
+
+Inputs:
+- manifest with annotations
+
+Outputs:
+- manifest with tags added
+
+author: orion.banks
+"""
+
+import synapseclient
+import argparse
+import pandas as pd
+from datetime import datetime
+
+### Login to Synapse ###
+def login():
+
+    syn = synapseclient.Synapse()
+    syn.login()
+
+    return syn
+
+
+def get_args():
+
+    parser = argparse.ArgumentParser(
+        description="Create lists of tags for icons on the CCKP"
+    )
+    parser.add_argument(
+        "-d", help="Path to manifest with annotations."
+    )
+    parser.add_argument(
+        "-t", help="Path to CSV with annotation-to-tag mappings."
+    )
+    return parser.parse_args()
+
+
+def collect_labels(database, terms, attributes):
+
+    database_df = pd.read_csv(database, header=0, na_values=None, keep_default_na=False)
+    component = str(database_df.iat[1,1])
+    data_type_prefix = component[:-4]
+    sep = " " if data_type_prefix == "Publication" else ""
+    tag_columns = [sep.join([data_type_prefix, a]) for a in attributes]
+
+    term_df = pd.read_csv(terms, header=0)
+    term_tuples = [(x, y) for x, y in zip(term_df["term"].to_list(), term_df["label"].to_list())]
+
+    database_df["iconTags"] = ""
+    
+    for _, row in database_df.iterrows():
+        annotations = []
+        for column in tag_columns:
+            print(f"Accessing annotations for column {column}")
+            annotations = annotations + row[column].split(", ")
+        print(f"Collected annotations: {annotations}")
+        labels = set([str(y) for x, y in term_tuples for n in annotations if n == x])
+        label_str = ", ".join(labels)
+        labels_str_trimmed = ", ".join(labels - {"nan"})
+        print(f"Labels associated with resource: {labels_str_trimmed}\n\n")
+        if label_str != "nan":
+            database_df.at[_, "iconTags"] = labels_str_trimmed
+    print(f"\nTags collected for attribute(s) {tag_columns} and stored in database")
+    
+    return database_df, component
+
+
+def main():
+
+    #syn = login()
+    args = get_args()
+    database = args.d
+    terms = args.t
+
+    attribute_list = ["Assay"]
+    
+    tagged_df, data_type = collect_labels(database, terms, attribute_list)
+    tagged_path = "_".join([data_type, "tagged", "-".join(attribute_list), datetime.now().strftime("%Y%m%d")])
+    output = tagged_df.to_csv(tagged_path + ".csv", index=False)
+    print(f"\nTagged resources are available at: {tagged_path}.csv")
+
+if __name__ == "__main__":
+    main()

--- a/portal_tables/build_tag_lists.py
+++ b/portal_tables/build_tag_lists.py
@@ -10,19 +10,9 @@ Outputs:
 author: orion.banks
 """
 
-import synapseclient
 import argparse
 import pandas as pd
 from datetime import datetime
-
-### Login to Synapse ###
-def login():
-
-    syn = synapseclient.Synapse()
-    syn.login()
-
-    return syn
-
 
 def get_args():
 
@@ -30,10 +20,10 @@ def get_args():
         description="Create lists of tags for icons on the CCKP"
     )
     parser.add_argument(
-        "-d", help="Path to manifest with annotations."
+        "-d", help="Path to manifest with annotations.", required=True
     )
     parser.add_argument(
-        "-t", help="Path to CSV with annotation-to-tag mappings."
+        "-t", help="Path to CSV with annotation-to-tag mappings.", required=True
     )
     return parser.parse_args()
 
@@ -47,7 +37,7 @@ def collect_labels(database, terms, attributes):
     tag_columns = [sep.join([data_type_prefix, a]) for a in attributes]
 
     term_df = pd.read_csv(terms, header=0)
-    term_tuples = [(x, y) for x, y in zip(term_df["term"].to_list(), term_df["label"].to_list())]
+    term_tuples = [(term, label) for term, label in zip(term_df["term"].to_list(), term_df["label"].to_list())]
 
     database_df["iconTags"] = ""
     
@@ -57,7 +47,7 @@ def collect_labels(database, terms, attributes):
             print(f"Accessing annotations for column {column}")
             annotations = annotations + row[column].split(", ")
         print(f"Collected annotations: {annotations}")
-        labels = set([str(y) for x, y in term_tuples for n in annotations if n == x])
+        labels = set([str(label) for term, label in term_tuples for annot in annotations if annot == term])
         label_str = ", ".join(labels)
         labels_str_trimmed = ", ".join(labels - {"nan"})
         print(f"Labels associated with resource: {labels_str_trimmed}\n\n")
@@ -70,7 +60,6 @@ def collect_labels(database, terms, attributes):
 
 def main():
 
-    #syn = login()
     args = get_args()
     database = args.d
     terms = args.t

--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -84,6 +84,7 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "DatasetTumorType",
         "DatasetGrantNumber",
         "DatasetPubmedId",
+        "iconTags"
     ]:
         df[col] = utils.convert_to_stringlist(df[col])
 
@@ -112,7 +113,8 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "pub",
         "link",
         "DatasetDoi",
-        "synapseLink"
+        "synapseLink",
+        "iconTags"
     ]
     return df[col_order]
 

--- a/portal_tables/sync_education.py
+++ b/portal_tables/sync_education.py
@@ -56,7 +56,8 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "ResourceMediaAccessibility",
         "ResourceAccessHazard",
         "ResourcePubmedId",
-        "ResourceDatasetAlias"
+        "ResourceDatasetAlias",
+        "iconTags"
     ]:
         df[col] = utils.convert_to_stringlist(pd.Series(df[col].values.flatten()))
 
@@ -87,7 +88,8 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "ResourceToolLink",
         "ResourceDoi",
         "synapseLink",
-        "ResourcePubmedId"
+        "ResourcePubmedId",
+        "iconTags"
     ]
     return df[col_order]
 

--- a/portal_tables/sync_publications.py
+++ b/portal_tables/sync_publications.py
@@ -58,7 +58,8 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "Publication Assay",
         "Publication Tumor Type",
         "Publication Tissue",
-        "Publication Grant Number"
+        "Publication Grant Number",
+        "iconTags"
     ]:
         df[col] = utils.convert_to_stringlist(df[col])
 
@@ -83,7 +84,7 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "grantName",
         "Publication Dataset Alias",
         "Publication Accessibility",
-        "entityId",
+        "iconTags"
     ]
     return df[col_order]
 

--- a/portal_tables/sync_tools.py
+++ b/portal_tables/sync_tools.py
@@ -62,6 +62,7 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "ToolLanguage",
         "ToolDownloadType",
         "ToolDocumentationType",
+        "iconTags"
     ]:
         df[col] = utils.convert_to_stringlist(df[col])
 
@@ -111,7 +112,8 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "ToolComputeRequirements",
         "ToolEntityName",
         "ToolEntityType",
-        "ToolEntityRole"
+        "ToolEntityRole",
+        "iconTags"
     ]
     return df[col_order]
 


### PR DESCRIPTION
Adds script that defines a new `iconTag` column. Script takes inputs:
- metadata CSV with relevant annotations, expected to be the QC'd tables derived from `union_qc.py`. Expected usage is to run `union_qc.py`, run `build_tag_lists.py`, upload to designated Synapse folder expected by syncing scripts
- term CSV with columns "term" and "label". Term contains annotations found in the metadata CSV, label contains the categorical terms that will be used for icons on the CCKP. This list is maintained in the data-models repo as modules/shared/mc2_iconTag_map_3-4-25.csv
- annotation types analyzed for tags are defined by attribute_list in main on row 78

I also adjusted the syncing scripts to handle the `iconTags` column, including conversion to string list and inclusion in final database CSVs