### PR TITLE
Update table_to_annotations.py

### DIFF
--- a/utils/table_to_annotations.py
+++ b/utils/table_to_annotations.py
@@ -97,7 +97,7 @@ def collect_biospecimen_annotations(
 
     component, table_id, column_list = specimen_info_tuple
     data_table = get_table(syn, table_id, column_list).set_index("Biospecimen_id")
-    column_list.pop(0)
+    column_list.pop(0) # remove Biospecimen_id from list of columns, since it is now the index
     biospecimen_ids = set(file_biospecimen_dict.values())
     filtered_metadata = data_table[data_table.index.isin(biospecimen_ids)]
     count = 0
@@ -132,9 +132,9 @@ def collect_record_annotations(
     apply annotations to each file"""
 
     component, table_id, column_list = info_tuple
-    key_column = "_".join([component, "id"])
+    key_column = f"{component}_id"
     data_table = get_table(syn, table_id, column_list).set_index(key_column)
-    column_list.pop(0)
+    column_list.pop(0)  # remove Component_id from list of columns, since it is now the index
     table_keys = set(tuple_dict.values())
     filtered_metadata = data_table[data_table.index.isin(table_keys)]
     count = 0


### PR DESCRIPTION
@vpchung when I went to run this, I realized that I did not test thoroughly enough before opening my PR.

There were two things I did that were causing some weirdness:
- I was applying annotations based on the number of entries in the metadata tables (when it should be the number of files in the dataset)
- I wrote everything using (record key, file id) tuples/dictionaries, when I should have been using (file id, record key). The record keys aren't necessarily unique, so I was overwriting the values. I didn't notice it until I went to apply individual metadata and the script was stopping at 84 entries (the # of rows in the individual table), when it should have been 253.

I added changes that appear to have fixed things. As always, I'm not sure if this is the "correct" way of doing it, but it does seem to be working as expected. 