### PR TITLE
Tools sync update

### DIFF
--- a/portal_tables/sync_tools.py
+++ b/portal_tables/sync_tools.py
@@ -36,8 +36,7 @@ def add_missing_info(tools: pd.DataFrame, grants: pd.DataFrame) -> pd.DataFrame:
                 synapse_links.append("".join(["[Link](", s , ")"]))
         tools.at[_, "synapseLink"] = ", ".join(set(synapse_links))
         
-        if tools.at[_,"PublicationViewKey"] == "":
-            tools.at[_,"PublicationViewKey"] = "Pending Annotation"
+        tools.at[_,"PublicationViewKey"] = tools.at[_,"PublicationViewKey"] or "Pending Annotation"
         
     return tools
 

--- a/portal_tables/sync_tools.py
+++ b/portal_tables/sync_tools.py
@@ -80,8 +80,6 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         for col in cols:
            df.at[_, col] = list(set(row[col]))
     
-    
-
     # Reorder columns to match the table order.
     col_order = [
         "ToolName",

--- a/portal_tables/sync_tools.py
+++ b/portal_tables/sync_tools.py
@@ -36,6 +36,9 @@ def add_missing_info(tools: pd.DataFrame, grants: pd.DataFrame) -> pd.DataFrame:
                 synapse_links.append("".join(["[Link](", s , ")"]))
         tools.at[_, "synapseLink"] = ", ".join(set(synapse_links))
         
+        if tools.at[_,"PublicationViewKey"] == "":
+            tools.at[_,"PublicationViewKey"] = "Pending Annotation"
+        
     return tools
 
 
@@ -50,7 +53,7 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
         "PublicationViewKey": "ToolPubmedId",
         "DatasetViewKey": "ToolDatasets"
         })
-    
+
     # Convert string columns to string-list.
     cols = [
         "ToolGrantNumber",
@@ -76,6 +79,8 @@ def clean_table(df: pd.DataFrame) -> pd.DataFrame:
     for _,row in df.iterrows():
         for col in cols:
            df.at[_, col] = list(set(row[col]))
+    
+    
 
     # Reorder columns to match the table order.
     col_order = [


### PR DESCRIPTION
This is intended to resolve the issue where non-related publications are listed for resources if a reference column (e.g., pubMedId) is empty