### PR TITLE
Create merge_and_correct_manifests.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ upload_check*
 annotations/inputs/*
 annotations/outputs/*
 annotations/output/*
+utils/example_files/*

--- a/utils/build_datasets.py
+++ b/utils/build_datasets.py
@@ -12,6 +12,7 @@ author: orion.banks
 import argparse
 import os
 import pandas as pd
+import random
 import re
 import synapseclient
 from synapseclient import Dataset
@@ -47,34 +48,54 @@ def get_table(syn, source_id: str) -> pd.DataFrame:
     return table
 
 
-def filter_files_in_folder(syn, scope: str, formats: list[str]) -> list:
+def filter_files_in_folder(syn, scope: str, formats: list[str], folder_or_files: str) -> list:
     """Capture all files in provided scope and select files that match a list of formats,
     return list of dataset items"""
 
     dataset_items = []
     walk_path = synapseutils.walk(syn, scope, ["file"])
     for *_, filename in walk_path:
-        for f, entity_id in filename:
-            if any(f.endswith(fmt) for fmt in formats):  # only select files of desired format
-                dataset_items.append({
+        if folder_or_files == "files":
+            file_to_add = [entity_id for f, entity_id in filename if any(f.endswith(fmt) for fmt in formats)]  # only select files of desired format
+        elif folder_or_files == "folder":
+            file_to_add = [entity_id for f, entity_id in filename]  # select all files in folder
+        for entity_id in file_to_add:
+            dataset_items.append({
                     "entityId": entity_id,
                     "versionNumber": syn.get(entity_id, downloadFile=False).versionLabel
                 })
-
+        dataset_len = len(dataset_items)
+        print(f"--> {dataset_len} files found...")
     return dataset_items
 
 
-def create_dataset_entity(syn, name: str, grant: str) -> Dataset:
+def create_dataset_entity(syn, name: str, grant: str, multi_dataset: bool, scope: list) -> tuple[Dataset, str]:
     """Create an empty Synapse Dataset using the
     Project associated with the applicable grant number as parent.
     Return the Dataset object."""
 
     query = f"SELECT grantId FROM syn21918972 WHERE grantViewId='{grant}'"
     project_id = syn.tableQuery(query).asDataFrame().iat[0, 0]
-    dataset = Dataset(name=name, parent=project_id)
+    if multi_dataset:
+        name = f"{name}-{random.randint(1000, 9999)}"  # append random number to name for multi-dataset
+    dataset = Dataset(name=name, parent=project_id, dataset_items=scope)
+    dataset = syn.store(dataset)
 
     return dataset
 
+def chunk_files_for_dataset(scope_files: list[str], file_max: int, dataset_total: int) -> list[list[str]]:
+    """Chunk files into lists of size file_max for Dataset creation."""
+    file_groups = []
+    i = 0
+    while i < dataset_total:
+        file_groups.append(scope_files[i * file_max:(i + 1) * file_max])
+        i += 1
+    if i == dataset_total:
+        if len(scope_files) % file_max != 0:
+            file_groups.append(scope_files[i * file_max:])
+        else:
+            file_groups.append(scope_files[(i - 1) * file_max:i * file_max])
+    return file_groups
 
 def main():
 
@@ -83,10 +104,14 @@ def main():
     args = get_args()
 
     dsp, new_name = args.d, args.n
-    update_dsp_sheet = None
     
+    update_dsp_sheet = None
+    create_dataset = False
+    multi_dataset = False
+    file_max = 5000  # maximum number of files per Dataset; set to 5000 to avoid web page latency issues
+
     if os.path.exists(dsp):
-        dsp_df = pd.read_csv(dsp, keep_default_na=False)
+        dsp_df = pd.read_csv(dsp, keep_default_na=False, header=0)
         print("\nData Sharing Plan read successfully!")
     elif "syn" in dsp:
         dsp_df = get_table(syn, dsp)
@@ -97,7 +122,8 @@ def main():
         )
         exit()
 
-    if dsp_df.iat[1, 0] == "DataDSP":
+    if dsp_df.iat[0, 0] == "DataDSP":
+        updated_df = pd.DataFrame(columns=dsp_df.columns)
         count = 0
         for _, row in dsp_df.iterrows():
             grant_id = row["GrantView Key"]
@@ -110,57 +136,81 @@ def main():
                 print(f"Skipping Dataset {dataset_name} of type {level}")
                 continue  # move to next table entry if not data files
             
-            print(f"\nProcessing Dataset {dataset_name}")
-            if dataset_id:  # check if a Dataset entity was previously recorded 
-                print(f"--> Accessing Dataset {dataset_id}")
-                dataset = syn.get(dataset_id)
-                print(f"--> {dataset_id} accessed!")
-            else:
-                print(
-                    f"--> A new Dataset will be created for files from {scope_id}"
-                )
-                dataset = create_dataset_entity(syn, dataset_name, grant_id)
-                update_dsp_sheet = True  # record the new DatasetView_id in DSP
-                print(f"--> New Dataset created!")
+            dataset_total = 1
+            dataset_id_list = []
+            file_scope_list = []
+            dataset_name_list = []
 
+            if dataset_id:  # check if a Dataset entity was previously recorded 
+                print(f"--> Files will be added to Dataset {dataset_id}")
+            else:
+                create_dataset = True
+                update_dsp_sheet = True
+            
             if formats:  # only filter files if formats were specified
                 print(f"--> Filtering files from {scope_id}")
-                scope_files = filter_files_in_folder(syn, scope_id, formats)
-                folder_or_files = "files"  # use add_items function
-                print(
-                    f"--> {scope_id} files filtered!\n    {len(scope_files)} files will be added to the Dataset."
-                )
+                folder_or_files = "files"  # filter files by extension/format
             else:
-                folder_or_files = "folder"  # whole folder should be added, use add_folder function
+                folder_or_files = "folder"  # whole folder should be added, don't filter files
+            
+            scope_files = filter_files_in_folder(syn, scope_id, formats, folder_or_files)
+            print(f"--> {scope_id} files acquired!\n    {len(scope_files)} files will be added to the Dataset.")
+            
+            if len(scope_files) > file_max:
+                new_dataset_count = (len(scope_files) // file_max)
+                dataset_total = dataset_total + new_dataset_count
+                multi_dataset = True
+                update_dsp_sheet = True
+                create_dataset = True
+                print(
+                    f"--> File count exceeds file max.\n--> Creating {dataset_total} groups for files from {scope_id}"
+                )
+                file_scope_list = chunk_files_for_dataset(scope_files, file_max, new_dataset_count)
+                
+            else:
+                multi_dataset = False
+                file_scope_list = [scope_files]  # single dataset, no chunking needed
 
-            if folder_or_files == "folder":
-                print(f"--> Adding Folder {scope_id} to Dataset {dataset_id}")
-                dataset.add_folder(scope_id, force=True)
-                print(f"--> Folder added to Dataset!")
-            elif folder_or_files == "files":
-                print(f"--> Adding Files from {scope_id} to Dataset {dataset_id}")
-                dataset.add_items(dataset_items=scope_files, force=True)
-                print(f"--> Files added to Dataset!")
+            if dataset_id:
+                dataset = syn.get(dataset_id, downloadFile=False)
+                dataset_id_list.append(dataset.id)
+                dataset_name_list.append(dataset.name)
+                dataset.add_items(dataset_items=file_scope_list[0], force=True)
+                syn.store(dataset)
+                print(f"--> Files added to existing Dataset {dataset.id}")
+                file_scope_list = file_scope_list[1:]  # remove first item, already added
 
-            dataset = syn.store(dataset)
-            print(f"Dataset {dataset_id} successfully stored in {dataset.parentId}")
-
-            if update_dsp_sheet is not None:
-                dataset_id = dataset.id
-                dsp_df.at[_, "DatasetView Key"] = dataset_id
-
+            if create_dataset:
+                for scope in file_scope_list:
+                    dataset = create_dataset_entity(syn, dataset_name, grant_id, multi_dataset, scope)
+                    print(f"--> New Dataset created and populated with files!")
+                    dataset_id_list.append(dataset.id)
+                    dataset_name_list.append(dataset.name)
+            
             count += 1
+
+            dataset_tuples = zip(dataset_id_list, dataset_name_list)
+
+            for dataset_id, name in dataset_tuples:
+                if update_dsp_sheet is not None:
+                    temp_df = dsp_df.copy()
+                    temp_df.iloc[[_]] = row
+                    temp_df.at[_, "DatasetView Key"] = dataset_id
+                    temp_df.at[_, "DSP Dataset Name"] = name
+                updated_df = pd.concat([updated_df, temp_df], ignore_index=True)
+            updated_df.drop_duplicates(subset=["DatasetView Key"], keep="last", inplace=True)
+
     else:
         print(
             f"❗❗❗ The table provided does not appear to be a Dataset Sharing Plan.❗❗❗\nPlease check its contents and try again."
         )
         exit()
     
-    print(f"\n\nDONE ✅\n{count} Datasets processed")
+    print(f"\n\nDONE ✅\n{count} DSP entries processed")
 
     if update_dsp_sheet is not None:
         dsp_path = f"{os.getcwd()}/{new_name}.csv"
-        dsp_df.to_csv(path_or_buf=dsp_path, index=False)
+        updated_df.to_csv(path_or_buf=dsp_path, index=False)
         print(f"\nDSP sheet has been updated\nPath: {dsp_path}")
 
 

--- a/utils/merge_and_correct_manifests.py
+++ b/utils/merge_and_correct_manifests.py
@@ -1,0 +1,111 @@
+"""merge_and_correct_manifests.py
+
+This script replaces entries in a metadata manifest based on a primary key field.
+It also fills empty cells in the updated database with 'Pending Annotation' or 'Not Applicable'
+for specific columns, depending on the data type.
+
+author: orion.banks
+"""
+
+import argparse
+import os
+import pandas as pd
+
+def get_args():
+    """Set up command-line interface and get arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-d",
+        type=str,
+        help="Path to merged metadata table with erroneous entries.",
+        required=True,
+        default=None,
+    )
+    parser.add_argument(
+        "-n",
+        type=str,
+        help="Path to CSV with corrected metadata entries.",
+        required=True,
+        default=None,
+    )
+    return parser.parse_args()
+
+
+def update_database(database_df: pd.DataFrame, new_entries_df: pd.DataFrame, index_col: str) -> pd.DataFrame:
+    """Update the database DataFrame with new entries based on the index column."""
+    database_df["index_col"] = database_df[index_col]
+    new_entries_df["index_col"] = new_entries_df[index_col]
+    database_df.set_index("index_col", inplace=True)
+    new_entries_df.set_index("index_col", inplace=True)
+
+    database_df.update(new_entries_df)
+
+    return database_df
+
+
+def fill_empty_cells(updated_database: pd.DataFrame, data_type: str) -> pd.DataFrame:
+    """Fill empty cells in the updated database with 'Pending Annotation' or 'Not Applicable'."""
+    
+    cols_to_fill = [
+        "Publication Assay",
+        "Publication Tumor Type",
+        "Publication Tissue",
+        "Publication Dataset Alias",
+        "PublicationView Key",
+        "Dataset Description",
+        "Dataset Design",
+        "Dataset Assay",
+        "Dataset Species",
+        "Dataset Tissue",
+        "Dataset Tumor Type",
+        "Dataset File Formats",
+        "Data Use Codes"       
+    ]
+
+    for _,row in updated_database.iterrows():
+        for col in updated_database.columns:
+            if pd.isna(row[col]) or row[col] == "" and col in cols_to_fill:
+                if data_type == "PublicationView" and row["Publication Accessibility"] == "Open Access":
+                    value = "Not Applicable"
+                else:
+                    value = "Pending Annotation"
+                updated_database.at[row.name, col] = value
+
+    return updated_database
+
+
+def main():
+    """Main function to merge corrected manifests."""
+    args = get_args()
+
+    database, new_entries = args.d, args.n
+
+    for sheet in [database, new_entries]:
+        if os.path.exists(sheet):
+            continue
+        else:
+            print(f"\n❗❗❗ The file {sheet} does not exist! ❗❗❗")
+            exit()
+
+    data_type = os.path.basename(database).split("_")[0]
+    index_col = data_type + "_id"
+
+    database_df = pd.read_csv(database, keep_default_na=False, index_col=False)
+    print(f"\nDatabase read successfully!")
+    new_entries_df = pd.read_csv(new_entries, keep_default_na=False, index_col=False)
+    print(f"\nNew_entries read successfully!")
+
+    updated_database = update_database(database_df, new_entries_df, index_col)
+    print(f"\nDatabase has been successfully updated!")
+
+    if data_type in ["PublicationView", "DatasetView"]:
+        updated_database = fill_empty_cells(updated_database, data_type)
+        print(f"\nEmpty cells filled successfully!")
+
+    updated_database_path = f"{os.getcwd()}/{data_type}_merged_corrected.csv"
+    updated_database.to_csv(path_or_buf=updated_database_path, index=False)
+    print(f"\nUpdated database has been saved\nPath: {updated_database_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a script that automates transfer of corrected entries in "updated" manifest to "merged" manifest. Merges based on the primary key of the entry. The script will also populate empty cells with placeholder annotations for publications and datasets