### PR TITLE
Modifying manifest filtering

### DIFF
--- a/utils/merge_and_correct_manifests.py
+++ b/utils/merge_and_correct_manifests.py
@@ -9,8 +9,10 @@ author: orion.banks
 """
 
 import argparse
+from datetime import datetime
 import os
 import pandas as pd
+import re
 
 def get_args():
     """Set up command-line interface and get arguments."""
@@ -31,6 +33,27 @@ def get_args():
     )
     return parser.parse_args()
 
+
+def filter_updated_manifest(new_entries_df: pd.DataFrame, index_col: str, data_type: str) -> pd.DataFrame:
+    """Update the database DataFrame with new entries based on the index column."""
+    filtered_entries_df = pd.DataFrame(columns=new_entries_df.columns)
+    updated_entries_df = pd.DataFrame(columns=new_entries_df.columns)
+    updated_count = 0
+
+    index_groups = new_entries_df.groupby(index_col, as_index=False)
+    for name, rows in index_groups.groups.items():
+        row_to_keep = index_groups.get_group(name)
+        if len(rows) > 1:
+            row_to_keep = row_to_keep[row_to_keep["Source"].isin(["Database"])]
+        else:
+            if row_to_keep["Source"].isin(["Updated"]).all():
+                updated_entries_df = pd.concat([updated_entries_df, row_to_keep])
+                updated_count += 1
+        filtered_entries_df = pd.concat([filtered_entries_df, row_to_keep])
+
+    updated_entries_df.to_csv(f"{os.getcwd()}/{data_type}_new_rows_{datetime.now().strftime('%Y%m%d')}.csv", index=False)
+
+    return filtered_entries_df
 
 def update_database(database_df: pd.DataFrame, new_entries_df: pd.DataFrame, index_col: str) -> pd.DataFrame:
     """Update the database DataFrame with new entries based on the index column."""
@@ -63,9 +86,11 @@ def fill_empty_cells(updated_database: pd.DataFrame, data_type: str) -> pd.DataF
         "Data Use Codes"       
     ]
 
+    current_cols_to_fill = [col for col in updated_database.columns if col in cols_to_fill]
+
     for _,row in updated_database.iterrows():
-        for col in updated_database.columns:
-            if pd.isna(row[col]) or row[col] == "" and col in cols_to_fill:
+        for col in current_cols_to_fill:
+            if pd.isna(row[col]) or row[col] == "" or re.match(r"^,+", row[col]):
                 if data_type == "PublicationView" and row["Publication Accessibility"] == "Open Access":
                     value = "Not Applicable"
                 else:
@@ -123,7 +148,13 @@ def main():
                 exit()
 
     data_type = os.path.basename(database).split("_")[0]
-    index_col = data_type + "_id"
+    
+    index_col_dict = {"PublicationView": "Pubmed Id",
+                      "DatasetView": "Dataset Alias",
+                      "ToolView": "ToolView_id",
+                      "EducationalResource": "EducationalResource_id"}
+    
+    index_col = index_col_dict.get(data_type)
 
     database_df = pd.read_csv(database, keep_default_na=False, index_col=False)
     print(f"\nDatabase read successfully!")
@@ -131,8 +162,9 @@ def main():
     if new_entries is not None:
         new_entries_df = pd.read_csv(new_entries, keep_default_na=False, index_col=False)
         print(f"\nNew_entries read successfully!")
-        new_entries_df.drop(["entityId", "iconTags", "Source"], axis=1, errors="ignore", inplace=True)
-        updated_database = update_database(database_df, new_entries_df, index_col)
+        filtered_entries_df = filter_updated_manifest(new_entries_df, index_col, data_type)
+        filtered_entries_df.drop(["entityId", "iconTags", "Source"], axis=1, errors="ignore", inplace=True)
+        updated_database = update_database(database_df, filtered_entries_df, index_col)
         print(f"\nDatabase has been successfully updated!")
     else:
         print(f"\nCurrent database will not be updated with corrected entries.")


### PR DESCRIPTION
Entries in updated manifest will be filtered according to the following logic: if two entries exist and one is labeled "Database", keep this entry and do not retain the other in the database if only one entry exists (either "Database" or "Updated") keep it in the database if only one entry exists and it is labeled "Updated", add it to a separate dataframe, which is returned for review as a CSV

Updated criteria for selecting columns to fill with Pending Annotation or Not Applicable

Added index col dictionary, since we aren't always using the component_id column for filtering