### PR TITLE
Add function to get dataset version

### DIFF
--- a/portal_tables/sync_datasets.py
+++ b/portal_tables/sync_datasets.py
@@ -47,7 +47,7 @@ def add_missing_info(
             print(f"Encountered error: {e}")
             pass
         version = dataset.version_number if dataset is not None and dataset.version_number is not None else 1
-        datasets.at[_, "version"] = version
+        datasets.at[_, "version"] = int(version)
         
         pub_titles = []
         pub_doi = []


### PR DESCRIPTION
If Dataset Alias is a Synapse Id, get the entity and report it's version number. This is stored and uploaded to the portal Datasets Merged table. Supports selection of relevant croissant metadata files.